### PR TITLE
[Refactor] 중복 코드 정리

### DIFF
--- a/REFACTORING_ANALYSIS.md
+++ b/REFACTORING_ANALYSIS.md
@@ -1,0 +1,559 @@
+# Murphy 리팩토링 분석 리포트
+
+> 분석 대상: Next.js 16 + React 19 + TypeScript + Tailwind 3.4 프로젝트
+> 범위: `src/` 디렉토리 (~292 파일), `public/` SVG 자산
+> 제외: `node_modules`, `.next`, `dist`, `build`, `test/`, `e2e/`, `prisma/`, `data/`
+> 작성일: 2026-04-25
+
+---
+
+## 목차
+
+1. [중복 코드 (Duplicated Code)](#1-중복-코드-duplicated-code)
+2. [유사 로직, 다른 구현 (Inconsistent Implementations)](#2-유사-로직-다른-구현-inconsistent-implementations)
+3. [Props Drilling / 과도한 Props](#3-props-drilling--과도한-props)
+4. [기타 리팩토링 후보 (긴 함수/네이밍)](#4-기타-리팩토링-후보)
+5. [Tailwind 디자인 토큰화 후보](#5-tailwind-디자인-토큰화-후보)
+6. [타입/상수 관리](#6-타입상수-관리)
+7. [커스텀 훅 추출 후보](#7-커스텀-훅-추출-후보)
+8. [성능 개선 후보](#8-성능-개선-후보-정적-분석)
+9. [아이콘 사용 패턴](#9-아이콘-사용-패턴)
+10. [요약 및 우선순위](#10-요약-및-우선순위)
+
+---
+
+## 1. 중복 코드 (Duplicated Code)
+
+### [중복] API 라우트 인증 체크 블록 반복
+
+- **위치**:
+  - [src/app/api/projects/route.ts:7-10, 24-27, 46-49](src/app/api/projects/route.ts)
+  - [src/app/api/projects/[projectId]/route.ts:10-13, 36-39](src/app/api/projects/[projectId]/route.ts)
+  - [src/app/api/topics/route.ts:7-10](src/app/api/topics/route.ts)
+  - [src/app/api/topics/[topicId]/issues/route.ts:41-44](src/app/api/topics/[topicId]/issues/route.ts)
+- **현재 상태**: 동일한 3~4줄 인증 체크 블록이 다수 라우트 핸들러에 복사됨
+  ```ts
+  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
+  if (!ownerId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
+  ```
+- **근거**: 정책 변경(에러 응답 형식, 세션 방식 등) 시 동일 수정이 여러 곳에 필요. 인증 우회/누락 리스크.
+- **개선 제안**: `withAuth(handler)` 래퍼 또는 Next.js `middleware.ts`에서 공통 인증 처리. 라우트는 인증된 `userId`를 인자로만 받음.
+- **우선순위**: **High**
+
+### [중복] API 라우트 try/catch → console.error + createErrorResponse
+
+- **위치**: 최소 50+ 라우트 핸들러
+  - [src/app/api/projects/route.ts:17-19, 39-41, 61-63](src/app/api/projects/route.ts)
+  - [src/app/api/issues/route.ts:41-43](src/app/api/issues/route.ts)
+  - [src/app/api/topics/route.ts:26-28](src/app/api/topics/route.ts)
+  - [src/app/api/issues/[issueId]/ideas/route.ts:37-39, 72-74](src/app/api/issues/[issueId]/ideas/route.ts)
+  - [src/app/api/issues/[issueId]/categories/route.ts:17-19, 57-59](src/app/api/issues/[issueId]/categories/route.ts)
+- **현재 상태**: 모든 라우트에서 동일한 catch 블록 패턴 반복
+  ```ts
+  } catch (error) {
+    console.error('[operation] failed:', error);
+    return createErrorResponse('[CODE]', 500);
+  }
+  ```
+- **근거**: 로깅 포맷/관측 체계 변경 시 일괄 대응 불가. 일부는 한글 메시지, 일부는 영문 메시지로 구현 차이 발생(2장 참고).
+- **개선 제안**: `withErrorHandler(handler, errorCode)` 고차 함수 도입 또는 Next.js `middleware.ts` 레벨 에러 핸들링.
+- **우선순위**: **High**
+
+### [중복] React Query mutation onError + toast 블록 반복
+
+- **위치**:
+  - [src/hooks/projects/use-project-mutation.ts:17-21, 36-38, 54-57](src/hooks/projects/use-project-mutation.ts)
+  - [src/hooks/issues/use-issue-mutation.ts:32-35, 68-69, 86-88](src/hooks/issues/use-issue-mutation.ts)
+  - [src/hooks/issues/use-idea-mutation.ts:51-53, 114-120, 155-161](src/hooks/issues/use-idea-mutation.ts)
+- **현재 상태**: 25+ mutation에서 동일 패턴 반복
+  ```ts
+  onError: (error: unknown) => {
+    const msg = error instanceof Error ? error.message : 'fallback';
+    console.error('[op]:', error);
+    toast.error(msg);
+  };
+  ```
+- **근거**: 토스트 정책, 로깅 정책 변경 시 모든 hook 수정 필요. 폴백 문자열도 제각각.
+- **개선 제안**: `createMutationErrorHandler(fallbackMsg)` 유틸 또는 `useApiMutation` 공통 훅.
+- **우선순위**: **High**
+
+### [중복] React Query queryKey 인라인 선언
+
+- **위치**:
+  - [src/hooks/projects/use-project-query.ts:6, 14](src/hooks/projects/use-project-query.ts)
+  - [src/hooks/issues/use-issue-query.ts:8, 20](src/hooks/issues/use-issue-query.ts)
+  - [src/hooks/topics/use-topic-query.ts:15, 21, 27](src/hooks/topics/use-topic-query.ts)
+  - [src/hooks/issues/use-category-mutation.ts:18](src/hooks/issues/use-category-mutation.ts)
+- **현재 상태**: `['projects']`, `['project', projectId]`, `['topics', topicId, 'issues']` 등 15+ 훅에 queryKey 문자열 리터럴 산재. invalidation 시 각 훅에서 개별 선언.
+- **근거**: 키 하나 바꾸면 invalidate 호출부가 누락될 위험. 타입 안전성 없음.
+- **개선 제안**: `queryKeys` 팩토리 파일 (`src/lib/query-keys.ts`) 도입.
+  ```ts
+  export const queryKeys = {
+    projects: { all: ['projects'] as const, detail: (id: string) => ['project', id] as const },
+    issues: { all: (topicId: string) => ['topics', topicId, 'issues'] as const, ... },
+  };
+  ```
+- **우선순위**: **Medium**
+
+### [중복] 수동 입력 유효성 체크
+
+- **위치**:
+  - [src/app/api/projects/route.ts:32-34](src/app/api/projects/route.ts)
+  - [src/app/api/topics/route.ts:15-20](src/app/api/topics/route.ts)
+  - [src/app/api/issues/route.ts:14-16](src/app/api/issues/route.ts)
+- **현재 상태**: `if (!title) return createErrorResponse(...)` 같은 수동 검사 산재.
+- **근거**: 스키마 기반 검증(zod 등) 부재로 검증 로직이 분산. 메시지 일관성 낮음.
+- **개선 제안**: zod 도입 후 `parseBody(schema)` 헬퍼로 통일. 또는 최소한 `validateRequired(fields)` 유틸 공유.
+- **우선순위**: **Medium**
+
+### [중복] `useRef` 기반 외부 클릭 감지 로직
+
+- **위치**:
+  - [src/projects/components/project-card/project-card.tsx:40-41, 71-78](src/projects/components/project-card/project-card.tsx)
+  - 기타 드롭다운 컴포넌트 (member-sidebar-item 등)
+- **현재 상태**: `mousedown` 이벤트 리스너 등록/해제 코드가 3+ 곳에 중복.
+- **개선 제안**: `useClickOutside(ref, handler)` 공용 훅 추출 (`src/hooks/use-click-outside.ts`).
+- **우선순위**: **Medium**
+
+### [중복] 텍스트에어리어 자동 높이 조절
+
+- **위치**: [src/issues/components/idea-card/idea-card.tsx:173-178](src/issues/components/idea-card/idea-card.tsx)
+- **현재 상태**: `textareaRef.current.style.height = 'auto'; ... = scrollHeight + 'px'` 수동 조작. 다른 입력 컴포넌트에서도 동일 필요 추정(추가 확인 필요).
+- **개선 제안**: `useAutoGrowTextarea` 훅 추출.
+- **우선순위**: **Low**
+
+---
+
+## 2. 유사 로직, 다른 구현 (Inconsistent Implementations)
+
+### [불일치] 인증 헬퍼 모듈 2개 공존 + 시그니처 상이
+
+- **위치**:
+  - [src/lib/utils/api-auth.ts:7-29](src/lib/utils/api-auth.ts) — `getAuthenticatedUserId(request?)` → `{ userId, error }` 객체 반환
+  - [src/lib/utils/auth-helpers.ts:6-17](src/lib/utils/auth-helpers.ts) — `getAuthenticatedUserId(req, issueId?)` → `string | null` 반환
+  - [src/lib/utils/api-auth.ts:37-45](src/lib/utils/api-auth.ts) — `getIssueUserId(issueId)` (제3의 방식)
+- **현재 상태**: 같은 이름의 함수가 서로 다른 파일에 있고 반환 타입/시그니처가 다름. 라우트마다 어느 쪽을 import 하는지 제각각.
+  - 객체 반환 방식 사용: `api/projects/route.ts`, `api/topics/route.ts`
+  - nullable 반환 방식 사용: `api/issues/[issueId]/ideas/route.ts:8`, `api/issues/[issueId]/ideas/[ideaId]/route.ts:7`
+  - `getIssueUserId` 사용: `api/issues/[issueId]/route.ts:6`
+- **근거**: 같은 이름이라 IDE 자동 import가 잘못된 모듈 불러올 여지. 반환 타입 불일치로 버그 발생 가능.
+- **개선 제안**: 하나의 모듈(`src/lib/auth/`)로 통합. `requireUser(req)` / `requireIssueAccess(req, issueId)`로 명명 분리 후 단일 반환 타입.
+- **우선순위**: **High**
+
+### [불일치] 에러 처리 패턴 3종 혼재
+
+- **위치**:
+  - 패턴 A (서비스 에러 문자열 매핑): [src/app/api/issues/[issueId]/route.ts:68-75](src/app/api/issues/[issueId]/route.ts)
+  - 패턴 B (단일 500 에러): [src/app/api/projects/[projectId]/route.ts:26-29](src/app/api/projects/[projectId]/route.ts)
+  - 패턴 C (`getServerSession` 직접 사용): [src/app/api/projects/[projectId]/members/route.ts:7-14](src/app/api/projects/[projectId]/members/route.ts)
+- **현재 상태**: 같은 종류의 라우트인데 에러 구조가 3가지로 갈림. 일부는 한글 로그, 일부는 영문 로그.
+- **개선 제안**: 서비스 레이어에서 정의된 `AppError` 클래스 throw → 공통 핸들러에서 code/status 매핑.
+- **우선순위**: **High**
+
+### [불일치] toast 에러 메시지 처리 방식 3종
+
+- **위치**:
+  - 패턴 A (커스텀 메시지 + 한글 폴백): [src/hooks/projects/use-project-mutation.ts:18-21](src/hooks/projects/use-project-mutation.ts)
+  - 패턴 B (폴백 없는 직접 표시): [src/hooks/issues/use-idea-mutation.ts:52, 116, 157](src/hooks/issues/use-idea-mutation.ts)
+  - 패턴 C (하드코드된 한글 문자열): [src/hooks/issues/use-issue-member-mutation.ts:51, 58](src/hooks/issues/use-issue-member-mutation.ts)
+- **현재 상태**: 100+ toast 호출에서 오류 표시 방식이 제각각.
+- **개선 제안**: `showErrorToast(error, fallbackKey)` 유틸로 통일. 한글 폴백은 메시지 사전에서 조회.
+- **우선순위**: **Medium**
+
+### [불일치] 모달 상태 관리 방식
+
+- **위치**:
+  - 패턴 A (Zustand 스토어만): [src/components/modal/invite-project-modal/use-invite-project-modal.tsx:7-28](src/components/modal/invite-project-modal/use-invite-project-modal.tsx)
+  - 패턴 B (스토어 + SSE broadcast 결합): [src/issues/components/close-issue-modal/use-close-issue-modal.ts:16-160](src/issues/components/close-issue-modal/use-close-issue-modal.ts)
+- **현재 상태**: 후자는 모달 close 핸들러에 broadcast 로직이 섞여 있음(46-53, 84-86줄). 관심사 분리 부족.
+- **개선 제안**: 모달은 순수 UI 상태만, broadcast는 별도 훅/side-effect로 분리.
+- **우선순위**: **Medium**
+
+### [불일치] 로딩 상태 명명/계산 방식
+
+- **위치**:
+  - `isLoading` 조합: [src/hooks/topics/use-topic-query.ts:36](src/hooks/topics/use-topic-query.ts)
+  - `isPending` 분리 노출: [src/hooks/issues/use-idea-mutation.ts:172-174](src/hooks/issues/use-idea-mutation.ts)
+  - 디바운스 로딩 커스텀 훅: [src/hooks/use-smart-loading.ts:3-20](src/hooks/use-smart-loading.ts)
+- **현재 상태**: 세 가지 다른 방식이 공존. 컴포넌트는 어느 API를 받는지 매번 확인 필요.
+- **개선 제안**: mutation은 `isPending`, query는 `isLoading` 컨벤션 확정 후 문서화.
+- **우선순위**: **Low**
+
+### [불일치] 날짜 포맷
+
+- **위치**: [src/projects/components/project-detail-page.tsx](src/projects/components/project-detail-page.tsx) (`toLocaleDateString('ko-KR', ...)`)
+- **현재 상태**: 날짜 포맷 유틸이 없어 각 컴포넌트에서 개별 처리. 대부분은 raw string 사용(추가 확인 필요).
+- **개선 제안**: `src/lib/utils/date.ts`에 `formatDate(iso, style)` 공용 함수 추출.
+- **우선순위**: **Low**
+
+### [불일치] API fetch 래퍼 사용 여부
+
+- **위치**:
+  - 래퍼 사용: [src/lib/api/project.ts:4-43](src/lib/api/project.ts) (`getAPIResponseData` 경유)
+  - 래퍼 미사용: [src/app/api/projects/[projectId]/members/route.ts:1-25](src/app/api/projects/[projectId]/members/route.ts)
+- **현재 상태**: 응답 형식 규약이 라우트별로 다를 여지.
+- **개선 제안**: 응답 형식은 `createSuccessResponse` / `createErrorResponse`로 통일하고, 이 래퍼를 벗어난 곳 점검.
+- **우선순위**: **Medium**
+
+---
+
+## 3. Props Drilling / 과도한 Props
+
+### [Props] CategoryCard — 14개 props
+
+- **위치**: [src/issues/components/categories/category-card.tsx:11-27](src/issues/components/categories/category-card.tsx)
+- **현재 상태**: `id, issueId, title, position, isMuted, children, hasActiveComment, status, onRemove, onPositionChange, onDrag, onDragStart, onDragEnd, checkCollision` — 핸들러 5개 + 상태 플래그 다수.
+- **근거**: 드래그/위치 관련 핸들러가 상위에서 계산되어 강제 drilling. 캔버스 관련 상태는 이미 Zustand에 있음.
+- **개선 제안**: 드래그/위치 관련 로직을 `CanvasContext` 또는 `useCategoryDrag` 훅으로 집약. props는 `id, issueId, status, children` 수준으로 축소.
+- **우선순위**: **High**
+
+### [Props] Canvas — 10개 props (다수 boolean flag)
+
+- **위치**: [src/issues/components/canvas/canvas.tsx:9-20](src/issues/components/canvas/canvas.tsx)
+- **현재 상태**: `showGrid, showControls, showMessage, showAddButton, enableAddIdea` 등 다수의 렌더 플래그 + 콜백.
+- **근거**: boolean flag가 많은 컴포넌트는 내부 조합 폭발(“flag hell”). 재사용보다 복합 조건이 더 복잡.
+- **개선 제안**: 슬롯/컴포지션 패턴 — `<Canvas><Canvas.Grid /><Canvas.Controls /></Canvas>` 구조로 분리.
+- **우선순위**: **Medium**
+
+### [Props] IdeaCard — 11개 props
+
+- **위치**: [src/issues/components/idea-card/idea-card.tsx:21-31](src/issues/components/idea-card/idea-card.tsx)
+- **현재 상태**: `IdeaWithPosition` 스프레드 + `issueId, status, isHotIdea, onVoteChange, onSave, onDelete, onClick, onPositionChange, disableAnimation` 6개 추가 콜백.
+- **근거**: `issueId, status` 같은 이슈 컨텍스트는 이미 `useIssueData` 스토어에 존재. 콜백도 Mutation 훅 직접 호출로 대체 가능.
+- **개선 제안**: 스토어에서 직접 꺼내고 콜백은 내부에서 mutation을 호출. props는 `idea: IdeaWithPosition` 하나로 수렴.
+- **우선순위**: **High**
+
+### [Props] MemberSidebarItem — 2단계 drilling
+
+- **위치**: [src/components/sidebar/member-sidebar-item.tsx:7-16](src/components/sidebar/member-sidebar-item.tsx)
+- **현재 상태**: `currentUserId, issueId, isQuickIssue` 3개가 상위(issue-detail-page) → sidebar → member-list → member-sidebar-item으로 변환 없이 전달됨.
+- **개선 제안**: `IssueContext`(currentUserId, issueId, isQuickIssue) 생성 후 사용처에서 직접 소비.
+- **우선순위**: **Medium**
+
+### [Props] CommentWindow / CommentList — drilling 경로
+
+- **위치**:
+  - [src/issues/components/issue-detail-page.tsx:43](src/issues/components/issue-detail-page.tsx)
+  - [src/issues/components/comments/comment-window.tsx:11-15](src/issues/components/comments/comment-window.tsx)
+  - [src/issues/components/comments/comment-list.tsx](src/issues/components/comments/comment-list.tsx)
+- **현재 상태**: 모달 상태 props가 2단계 전달. 이미 `useCommentWindowStore`가 부분 존재.
+- **개선 제안**: `useCommentWindowStore`로 일관되게 치환.
+- **우선순위**: **Low**
+
+---
+
+## 4. 기타 리팩토링 후보
+
+### [긴 함수] issue-detail-page.tsx — 419줄
+
+- **위치**: [src/issues/components/issue-detail-page.tsx:37-178](src/issues/components/issue-detail-page.tsx)
+- **현재 상태**: 6개 이상의 useEffect가 권한 체크, auto-join, 리다이렉트, SSE 설정을 순차 처리. 복합 boolean(`isReadOnlySummaryView`)도 본문에서 계산.
+- **개선 제안**: `useIssuePermissions(issue, user)` 훅, `useIssueAutoJoin`, `useIssueRedirect` 등 관심사별 훅 추출.
+- **우선순위**: **High**
+
+### [긴 함수] use-issue-events.ts — 355줄, 단일 useEffect 안 20+ 리스너
+
+- **위치**: [src/issues/hooks/use-issue-events.ts:59-330](src/issues/hooks/use-issue-events.ts) (추가 확인 필요)
+- **현재 상태**: 하나의 useEffect에서 20+ SSE 이벤트를 수신하고 각각 query invalidation. 121-135, 108-290줄에서 유사 블록 반복.
+- **개선 제안**: `eventHandlers` 맵(이벤트명 → 핸들러)으로 선언형 변환. 도메인별(카테고리/아이디어/투표)로 훅 분할.
+- **우선순위**: **High**
+
+### [긴 함수] idea-card.tsx — 268줄
+
+- **위치**: [src/issues/components/idea-card/idea-card.tsx](src/issues/components/idea-card/idea-card.tsx)
+- **현재 상태**: 뷰와 훅 로직 혼재(75-156줄 setup). `useIdeaCard`로 일부 분리는 되어 있음.
+- **개선 제안**: 남아있는 ref/애니메이션 로직을 `useIdeaCardAnimation` 등으로 추가 분리.
+- **우선순위**: **Medium**
+
+### [긴 함수] comment-window.tsx — 250줄
+
+- **위치**: [src/issues/components/comments/comment-window.tsx:18-99](src/issues/components/comments/comment-window.tsx)
+- **현재 상태**: 8개 상태 destructure + 컨텍스트 provider. 구조 자체는 양호.
+- **개선 제안**: 유지. 필요 시 CommentInput/CommentBody 분리.
+- **우선순위**: **Low**
+
+### [네이밍] 이벤트 핸들러 네이밍은 대체로 일관적
+
+- **위치**: 전반
+- **현재 상태**: 내부는 `handle*`, props 로 받는 콜백은 `on*`이 잘 지켜지고 있음.
+- **우선순위**: — (개선 불필요)
+
+### [복잡 조건문] 주목할 수준의 3+ 단계 중첩 삼항 연산자는 발견되지 않음
+
+- **위치**: [src/issues/components/comments/hooks/use-comment-list.ts:46-57](src/issues/components/comments/hooks/use-comment-list.ts)가 가장 깊은 편(2단계, 허용 수준).
+- **우선순위**: **Low**
+
+---
+
+## 5. Tailwind 디자인 토큰화 후보
+
+### [Tailwind] 현재 `tailwind.config.ts`에 정의된 토큰
+
+- **위치**: [tailwind.config.ts:18-48](tailwind.config.ts)
+- **현재 상태**:
+  - `borderRadius`: half / large / medium / small
+  - `fontSize`: xxl / xl / large / medium / small / xs
+  - `fontWeight`: regular / medium / semibold / bold
+  - `zIndex`: hide / base / important / selected / sticky / backdrop / modal / popover / overlay
+  - **colors 토큰은 정의되어 있지 않음** — 모든 색상이 기본 팔레트 또는 arbitrary value.
+
+### [Tailwind] 가장 많이 쓰이는 색상 TOP 10
+
+| 순위 | 클래스            | 빈도 |
+| ---- | ----------------- | ---- |
+| 1    | `border-gray-200` | 32   |
+| 2    | `text-gray-900`   | 24   |
+| 3    | `text-gray-500`   | 24   |
+| 4    | `text-gray-400`   | 24   |
+| 5    | `bg-gray-100`     | 22   |
+| 6    | `bg-green-600`    | 21   |
+| 7    | `bg-gray-50`      | 20   |
+| 8    | `text-gray-600`   | 19   |
+| 9    | `bg-gray-200`     | 19   |
+| 10   | `text-green-600`  | 17   |
+
+- **근거**: 다수 회 재사용되는 색상은 semantic token으로 승격 시 일괄 변경/브랜딩 대응 용이.
+- **개선 제안**: `theme.extend.colors`에 semantic alias 추가 (예: `surface.base` → `gray-50`, `surface.muted` → `gray-100`, `border.default` → `gray-200`, `text.primary` → `gray-900`, `text.secondary` → `gray-500`, `brand.primary` → `green-600`).
+- **우선순위**: **Medium**
+
+### [Tailwind] Gray 계열 혼용 (의미 중복 가능성)
+
+- **현재 상태**:
+  - 배경용으로 `gray-50`(20x), `gray-100`(22x), `gray-200`(19x), `gray-300`(7x) **네 단계** 공존
+  - 텍스트용으로 `gray-400/500/600/700/800/900` **여섯 단계** 공존
+  - 경계선 대부분 `border-gray-200`이나 `gray-100`, `gray-300`도 산발적으로 쓰임
+- **근거**: 단계가 너무 많으면 디자인 정합성 저하, 의미 상 “같은 것”을 다른 단계로 작성한 사례가 생김.
+- **개선 제안**: 배경 2단계(`surface`, `surface-muted`), 텍스트 3단계(`primary`, `secondary`, `tertiary`)로 수렴. 혼용 위치를 디자이너와 조율 후 일괄 치환.
+- **우선순위**: **Medium**
+
+### [Tailwind] arbitrary 색상값이 기본 팔레트와 중복
+
+- **위치**: 23개 고유 arbitrary 색상 발견
+  - `text-[#6b7280]` (2x) → `gray-500`과 동일
+  - `text-[#111827]` (2x) → `gray-900`과 동일
+  - `border-[#e5e7eb]` → `gray-200`과 동일
+  - `bg-[#00a94f]`, `text-[#00a94f]`, `border-[#00a94f]` — 브랜드 그린 (토큰화 필요)
+  - 기타: `#fbd6d0`, `#f3f4f6`, `#e2e8f0`, `#7fc196`, `#fef3c7`, `#fafafa`, `#f8fafc`, `#d4eddc`, `#c9c9c9`, `#92400e`
+- **근거**: 기본 팔레트로 표현 가능한 색을 arbitrary로 쓰면 IDE 색상 미리보기/일괄 변경 어려움. 브랜드 컬러는 반드시 토큰화.
+- **개선 제안**:
+  1. `brand.primary: '#00a94f'` 토큰 추가 후 3곳 치환
+  2. 팔레트와 동일한 hex는 `gray-500` 등 Tailwind 기본 클래스로 치환
+  3. 남은 개별 hex는 의미 확인 후 semantic token으로 재분류 또는 유지
+- **우선순위**: **Medium**
+
+---
+
+## 6. 타입/상수 관리
+
+### [타입] Member 관련 타입 3종 파편화
+
+- **위치**:
+  - [src/projects/types/project.ts:11](src/projects/types/project.ts) — `ProjectMember { user: { id, image, displayName } }`
+  - [src/issues/types/issue.ts:7](src/issues/types/issue.ts) — `IssueMember { id, nickname, role, isConnected }`
+  - [src/projects/types/project.ts:38-42](src/projects/types/project.ts) — `ProjectwithTopic.members` 인라인 shape
+- **현재 상태**: 세 가지가 호환되지 않는 구조. 공통 `User`/`Member` 기반 타입 없음.
+- **개선 제안**: `src/types/member.ts`에 `BaseMember`, 확장으로 `ProjectMember`, `IssueMember`. Prisma 모델 기반 타입 재사용 검토.
+- **우선순위**: **High**
+
+### [타입] `Issue` 관련 타입 중복
+
+- **위치**:
+  - [src/issues/types/issue.ts:15-24](src/issues/types/issue.ts) — `Issue` interface
+  - [src/projects/types/project.ts:29](src/projects/types/project.ts) — `ProjectwithTopic` 내부에 Issue-like 인라인 정의
+- **현재 상태**: 이슈 표현이 두 군데 정의.
+- **개선 제안**: `src/types/`로 중앙화, `Pick`/`Omit`으로 파생.
+- **우선순위**: **Medium**
+
+### [상수] 캔버스/레이아웃 매직 넘버 다수
+
+- **위치**:
+  - [src/issues/components/canvas/canvas.tsx:68, 77-78](src/issues/components/canvas/canvas.tsx) — `[background-size:40px_40px]`, `4000px`
+  - [src/issues/components/comments/comment-window.tsx:122](src/issues/components/comments/comment-window.tsx) — `bottom-[-340px] right-[-400px]`, `h-[500px] w-[420px]`, `max-h-[min(800px,calc(100vh-32px))]`
+  - [src/issues/components/idea-card/idea-card.tsx:34](src/issues/components/idea-card/idea-card.tsx) — `min-w-[30em] max-w-[30em] px-[35px] pb-[30px] pt-[35px]`
+- **현재 상태**: 레이아웃 치수가 JSX에 하드코딩.
+- **개선 제안**: `src/constants/layout.ts`에 `CANVAS_SIZE_PX`, `COMMENT_WINDOW_WIDTH_PX` 등으로 수렴. 디자이너 토큰화 병행.
+- **우선순위**: **Medium**
+
+### [상수] 그림자/시각 토큰 산발
+
+- **위치**: 전반 (예: `shadow-[0_20px_60px_rgba(0,0,0,0.2)]` 등 15+ 고유 값, 추가 확인 필요)
+- **개선 제안**: `tailwind.config.ts`의 `boxShadow.extend`에 semantic key로 등록.
+- **우선순위**: **Low**
+
+### [환경변수] `process.env` 직접 참조
+
+- **위치**:
+  - [src/proxy.ts](src/proxy.ts) — `process.env.NEXTAUTH_SECRET`
+  - [src/app/sitemap.ts](src/app/sitemap.ts) — `process.env.BASE_URL`
+  - [src/app/api/issues/[issueId]/categorize/route.ts](src/app/api/issues/[issueId]/categorize/route.ts) — `process.env.CLOVA_API_KEY`
+  - [src/lib/redis.ts](src/lib/redis.ts) — Redis 호스트/포트 등 직접 참조 (추가 확인 필요)
+- **현재 상태**: 일부는 `src/lib/auth.ts`/`src/lib/prisma.ts`에서 중앙화되었으나 API 라우트는 여전히 직접 참조.
+- **개선 제안**: `src/lib/config.ts` 단일 진입점 + 타입 보장 (zod `parseEnv` 권장).
+- **우선순위**: **Medium**
+
+---
+
+## 7. 커스텀 훅 추출 후보
+
+### [훅] 이미 존재하는 것 (약 58개 훅)
+
+- `src/hooks/issues/` 14개, `src/hooks/topics/` 8개, `src/hooks/projects/` 4개, `src/hooks/comments/` 5개 등. 전반적으로 추출 수준은 양호.
+
+### [훅] 추출되지 않은 반복 패턴
+
+- **useClickOutside** — 외부 클릭 감지 로직이 3+ 군데 중복(1장 참고). 추출 후보.
+- **useAutoGrowTextarea** — 텍스트에어리어 자동 높이 조절(1장 참고).
+- **useIssuePermissions** — `issue-detail-page.tsx` 권한/리드온리 판정 로직(4장 참고). 100줄 가까이 차지.
+- **useMutationErrorToast** — `onError` → toast + 로그 공통 패턴(1장 참고).
+- **우선순위**: **Medium** (개별적으로는 Low, 묶으면 Medium)
+
+---
+
+## 8. 성능 개선 후보 (정적 분석)
+
+### [성능] `key={index}` 사용 — **없음** ✅
+
+- **위치**: 전체 검색 결과 발견되지 않음.
+- **현재 상태**: 양호.
+
+### [성능] `<img>` 태그 — **없음** ✅
+
+- **위치**: 전체에서 `<img>` 태그 발견되지 않음. 모든 이미지가 `next/image` 사용.
+
+### [성능] `import *` 네임스페이스 임포트 11곳
+
+- **위치**: 대부분 repository 배럴 (`import * as ideaRepository from '@/lib/repositories'`) — Next.js 서버 컴포넌트에서 허용되는 패턴.
+- **주의 대상**: `import * as S from '@/components/sidebar'` 식 UI 네임스페이스 2곳 — 명시적 named import로 바꾸면 트리셰이킹에 더 안전.
+- **우선순위**: **Low**
+
+### [성능] `@xyflow/react` 정적 임포트 5곳
+
+- **위치**:
+  - `src/topics/components/topic-canvas.tsx`
+  - `src/topics/components/issue-node.tsx`
+  - `src/topics/components/issue-handle.tsx`
+  - `src/topics/components/Issue-edge.tsx` (파일명 대소문자 주의)
+  - `src/topics/components/issue-connection-line.tsx`
+- **현재 상태**: 그래프 시각화 라이브러리를 정적으로 로드. `/topics` 라우트에서만 사용되지만 다른 페이지에도 영향 가능.
+- **개선 제안**: 상위 페이지에서 `dynamic(() => import('...'), { ssr: false })`로 lazy-load. 번들 분리 효과 기대.
+- **주의**: 프로파일링 전 단정 금지. **후보** 수준.
+- **우선순위**: **Medium**
+
+### [성능] `wordcloud` — 이미 dynamic
+
+- **위치**: [src/issues/components/summary/word-cloud/word-cloud.tsx:45](src/issues/components/summary/word-cloud/word-cloud.tsx) — `import('wordcloud').then(...)` ✓
+- **현재 상태**: 이미 lazy-load됨. 조치 불필요.
+
+### [성능] 인라인 객체/함수 prop (약 23곳 `style={{...}}`)
+
+- **주요 위치**:
+  - [src/issues/components/idea-card/idea-card-header.tsx](src/issues/components/idea-card/idea-card-header.tsx)
+  - `src/topics/components/issue-node-skeleton-grid/` — 반복 렌더되는 grid item
+  - [src/issues/components/canvas/canvas.tsx](src/issues/components/canvas/canvas.tsx)
+- **현재 상태**: 일부는 뷰포트 좌표 등 동적 값이라 정상. 반복 렌더 핫스팟(skeleton grid 등)은 리렌더 유발 가능.
+- **개선 제안**: 핫 경로만 `useMemo`로 객체 메모이즈 또는 Tailwind 클래스로 이동.
+- **주의**: 실제 측정 없이 최적화하지 말 것.
+- **우선순위**: **Low**
+
+---
+
+## 9. 아이콘 사용 패턴
+
+### [아이콘] 현황
+
+- **위치**: [public/](public/) 디렉토리
+- **전체**: 36개 SVG 파일
+- **사용 방식**: `<Image>` 컴포넌트 + `src` 속성으로 문자열 경로 전달 (SVGR/스프라이트 미사용)
+- **`<img>` 태그 사용**: 0건 (양호)
+
+### [아이콘] 색상 변형 중복 파일
+
+| 의미    | 파일들                                               | 비고                                |
+| ------- | ---------------------------------------------------- | ----------------------------------- |
+| crown   | `crown.svg`, `yellow-crown.svg`, `summary-crown.svg` | 3종                                 |
+| add     | `add.svg`, `white-add.svg`                           | 2종 (white는 4곳 사용)              |
+| edit    | `edit.svg`, `edit-gray.svg`                          | 2종                                 |
+| people  | `people.svg`, `green-people.svg`                     | green은 **사용처 0건 (dead asset)** |
+| comment | `comment.svg`, `green-comment.svg`                   | green은 **사용처 0건 (dead asset)** |
+
+**중복/사용 안 되는 것 추정**:
+
+- 색상 변형 중복: 최소 9개 파일 (5세트)
+- Dead asset: 2개 (`green-people.svg`, `green-comment.svg`)
+
+### [아이콘] 추천 개선 방향
+
+프로젝트가 **Next.js 16**이므로 다음 중 하나 권장:
+
+**권장 1순위 — SVGR + `currentColor`**
+
+- 장점: 색상을 `className`(Tailwind text-\*)으로 제어 → 파일 분할 불필요
+- 절차:
+  1. `@svgr/webpack` 설치 후 `next.config.ts`에 webpack 설정 추가
+  2. SVG 파일 내 `fill="#..."`을 `fill="currentColor"`로 수정
+  3. 컴포넌트로 import: `import CrownIcon from '@/icons/crown.svg'`
+  4. 사용: `<CrownIcon className="text-yellow-500" />`
+- 중복 파일 5세트를 각 1개로 수렴 가능 → 최소 7개 파일 감소
+
+**권장 2순위 — SVG sprite**
+
+- 아이콘이 수백 개로 늘어날 때 고려. 현재 36개 수준에서는 과공학.
+
+- **주의**: 파일 삭제/변환은 하지 말고 계획만 제시.
+- **우선순위**: **High** (대표적인 리팩토링 저효율 지점, ROI 큼)
+
+---
+
+## 10. 요약 및 우선순위
+
+### High 우선순위 (영향 범위 넓음 + ROI 큼)
+
+1. **API 인증/에러 처리 통합** — 2개 인증 헬퍼 일원화, 50+ try/catch 블록 고차 함수화
+2. **Mutation 에러 처리 공용 훅 추출** — 25+ mutation의 onError 통합
+3. **Member/Issue 타입 중앙화** — `src/types/`로 수렴
+4. **Props가 많은 컴포넌트 리팩토링** — CategoryCard(14), IdeaCard(11)
+5. **issue-detail-page.tsx 훅 분리** — 419줄, 권한/리다이렉트/SSE 로직 분산
+6. **use-issue-events.ts 선언형 전환** — 355줄 단일 useEffect 분해
+7. **SVG 아이콘 SVGR + currentColor 전환** — 색상 변형 중복 5세트 + dead asset 2개
+
+### Medium 우선순위
+
+1. Query key 팩토리 (`src/lib/query-keys.ts`)
+2. Tailwind semantic color 토큰 추가 + arbitrary hex 정리 (브랜드 `#00a94f` 우선)
+3. Gray 단계 수렴 (배경 2, 텍스트 3 권장)
+4. Canvas/레이아웃 매직넘버 상수화
+5. 환경변수 중앙 config
+6. `useClickOutside` / `useAutoGrowTextarea` 훅 추출
+7. `@xyflow/react` dynamic import 검토
+8. zod 기반 요청 검증 도입
+9. Canvas 컴포넌트 composition 패턴 변경
+10. 모달+SSE broadcast 관심사 분리
+
+### Low 우선순위
+
+1. 날짜 포맷 유틸
+2. 로딩 상태 명명 컨벤션 문서화
+3. CommentWindow/CommentList drilling → store 치환
+4. box-shadow 토큰화
+5. UI 네임스페이스 `import *` → named import
+6. 반복 렌더 영역의 인라인 `style={{...}}` 정리 (프로파일링 선행)
+
+### 추가 확인 필요 항목
+
+- `src/lib/redis.ts` 환경변수 참조 라인 정확도
+- `use-issue-events.ts` 355줄 상세 구조 (줄 번호 정확도)
+- 날짜 포맷이 사용되는 모든 위치 (`toLocaleDateString` grep 추가 필요)
+- box-shadow arbitrary value 정확한 중복 개수
+- 텍스트에어리어 자동 높이 조절 패턴의 다른 사용처
+
+### 분석에서 제외한 것
+
+- UI/UX 개선 (색상 톤, 레이아웃 느낌, 접근성, 애니메이션)
+- 비즈니스 로직 변경이 필요한 사항
+- 단순 스타일 취향 차이
+
+---
+
+_본 리포트는 정적 분석 결과이며, 실제 리팩토링 전에 각 항목을 팀 리뷰 및 런타임 프로파일링(성능 항목 한정)으로 재검증할 것을 권장합니다._

--- a/src/app/api/auth/provider/route.ts
+++ b/src/app/api/auth/provider/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import * as userRepository from '@/lib/repositories/user.repository';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET() {
   try {
@@ -15,7 +15,6 @@ export async function GET() {
 
     return createSuccessResponse(providers);
   } catch (error) {
-    console.error('get providers error', error);
-    return createErrorResponse('GET_PROVIDERS_ERROR', 500);
+    return handleApiError(error, 'GET_PROVIDERS_ERROR');
   }
 }

--- a/src/app/api/auth/withdraw/route.ts
+++ b/src/app/api/auth/withdraw/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { deleteUser } from '@/lib/repositories/user.repository';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function DELETE() {
   try {
@@ -17,8 +17,7 @@ export async function DELETE() {
 
     return createSuccessResponse({ message: '회원탈퇴가 완료되었습니다.' });
   } catch (error) {
-    console.error('회원탈퇴 에러:', error);
-    return createErrorResponse('INTERNAL_SERVER_ERROR', 500);
+    return handleApiError(error, 'INTERNAL_SERVER_ERROR');
   }
 }
 

--- a/src/app/api/issues/[issueId]/categories/route.ts
+++ b/src/app/api/issues/[issueId]/categories/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { categoryRepository } from '@/lib/repositories/category.repository';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  handleApiError,
+} from '@/lib/utils/api-helpers';
 
 export async function GET(
   _req: NextRequest,
@@ -15,7 +19,7 @@ export async function GET(
 
     return createSuccessResponse(categories);
   } catch (error) {
-    return handleApiError(error, 'INTERNAL_ERROR');
+    return handleApiError(error, 'INTERNAL_SERVER_ERROR');
   }
 }
 

--- a/src/app/api/issues/[issueId]/categories/route.ts
+++ b/src/app/api/issues/[issueId]/categories/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { categoryRepository } from '@/lib/repositories/category.repository';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(
   _req: NextRequest,
@@ -15,8 +15,7 @@ export async function GET(
 
     return createSuccessResponse(categories);
   } catch (error) {
-    console.error('카테고리 조회 실패:', error);
-    return createErrorResponse('INTERNAL_ERROR', 500);
+    return handleApiError(error, 'INTERNAL_ERROR');
   }
 }
 
@@ -55,7 +54,6 @@ export async function POST(
 
     return createSuccessResponse(category, 201);
   } catch (error) {
-    console.error('카테고리 생성 실패:', error);
-    return createErrorResponse('CATEGORY_CREATE_FAILED', 500);
+    return handleApiError(error, 'CATEGORY_CREATE_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/categorize/route.ts
+++ b/src/app/api/issues/[issueId]/categorize/route.ts
@@ -6,7 +6,7 @@ import { findIssueById } from '@/lib/repositories/issue.repository';
 import { categorizeService } from '@/lib/services/categorize.service';
 import { broadcast } from '@/lib/sse/sse-service';
 import { validateAIFunctionCallResponse } from '@/lib/utils/ai-response-validator';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { broadcastError } from '@/lib/utils/broadcast-helpers';
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ issueId: string }> }) {
@@ -114,9 +114,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ iss
 
     return createSuccessResponse(result);
   } catch (error) {
-    console.error('[AI 카테고리화] 에러 발생:', error);
     broadcastError(issueId, '서버 내부 오류로 AI 분류에 실패했습니다.');
-
-    return createErrorResponse('AI_CATEGORIZATION_FAILED', 500);
+    return handleApiError(error, 'AI_CATEGORIZATION_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/ideas/[ideaId]/comments/route.ts
+++ b/src/app/api/issues/[issueId]/ideas/[ideaId]/comments/route.ts
@@ -3,7 +3,7 @@ import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { commentRepository } from '@/lib/repositories/comment.repository';
 import { ideaRepository } from '@/lib/repositories/idea.repository';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 /**
  * [GET] 특정 아이디어 댓글 목록 조회 API
@@ -19,8 +19,7 @@ export async function GET(
     const comments = await commentRepository.findByIdeaId(ideaId, issueId);
     return createSuccessResponse(comments);
   } catch (error) {
-    console.error('댓글 조회 중 오류 발생:', error);
-    return createErrorResponse('COMMENT_FETCH_FAILED', 500);
+    return handleApiError(error, 'COMMENT_FETCH_FAILED');
   }
 }
 
@@ -65,7 +64,6 @@ export async function POST(
 
     return createSuccessResponse(comment, 201);
   } catch (error) {
-    console.error('댓글 생성 중 오류 발생:', error);
-    return createErrorResponse('COMMENT_CREATE_FAILED', 500);
+    return handleApiError(error, 'COMMENT_CREATE_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/ideas/[ideaId]/route.ts
+++ b/src/app/api/issues/[issueId]/ideas/[ideaId]/route.ts
@@ -3,7 +3,7 @@ import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { ideaRepository } from '@/lib/repositories/idea.repository';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { getAuthenticatedUserId } from '@/lib/utils/auth-helpers';
 
 export async function GET(
@@ -33,8 +33,7 @@ export async function GET(
       issueMember: issueMember ? { nickname: issueMember.nickname } : null,
     });
   } catch (error) {
-    console.error('아이디어 상세 조회 실패:', error);
-    return createErrorResponse('IDEA_DETAIL_FETCH_FAILED', 500);
+    return handleApiError(error, 'IDEA_DETAIL_FETCH_FAILED');
   }
 }
 

--- a/src/app/api/issues/[issueId]/ideas/[ideaId]/select/route.ts
+++ b/src/app/api/issues/[issueId]/ideas/[ideaId]/select/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { prisma } from '@/lib/prisma';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function POST(
   req: NextRequest,
@@ -48,7 +48,6 @@ export async function POST(
 
     return createSuccessResponse({ ok: true });
   } catch (error) {
-    console.error('선택된 아이디어를 브로드캐스팅 중 오류가 발생했습니다: ', error);
-    return createErrorResponse('IDEA_SELECTION_BROADCAST_FAILED', 500);
+    return handleApiError(error, 'IDEA_SELECTION_BROADCAST_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/ideas/[ideaId]/vote/route.ts
+++ b/src/app/api/issues/[issueId]/ideas/[ideaId]/vote/route.ts
@@ -4,7 +4,7 @@ import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { authOptions } from '@/lib/auth';
 import { voteService } from '@/lib/services/vote.service';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { getUserIdFromRequest } from '@/lib/utils/cookie';
 
 export async function POST(
@@ -49,7 +49,6 @@ export async function POST(
 
     return createSuccessResponse(result);
   } catch (error) {
-    console.error('투표 실패:', error);
-    return createErrorResponse('VOTE_FAILED', 500);
+    return handleApiError(error, 'VOTE_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/ideas/route.ts
+++ b/src/app/api/issues/[issueId]/ideas/route.ts
@@ -4,7 +4,7 @@ import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 import { ideaRepository } from '@/lib/repositories/idea.repository';
 import { ideaFilterService } from '@/lib/services/idea-filter.service';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { getAuthenticatedUserId } from '@/lib/utils/auth-helpers';
 
 export async function GET(
@@ -35,8 +35,7 @@ export async function GET(
 
     return createSuccessResponse(ideas);
   } catch (error) {
-    console.error('아이디어 조회 실패:', error);
-    return createErrorResponse('IDEA_FETCH_FAILED', 500);
+    return handleApiError(error, 'IDEA_FETCH_FAILED');
   }
 }
 
@@ -70,7 +69,6 @@ export async function POST(
 
     return createSuccessResponse(newIdea, 201);
   } catch (error) {
-    console.error('아이디어 생성 실패:', error);
-    return createErrorResponse('IDEA_CREATE_FAILED', 500);
+    return handleApiError(error, 'IDEA_CREATE_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/members/[userId]/route.ts
+++ b/src/app/api/issues/[issueId]/members/[userId]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { issueMemberService } from '@/lib/services/issue-member.service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { broadcast } from '@/lib/sse/sse-service';
 import { SSE_EVENT_TYPES } from '@/constants/sse-events';
 
 export async function GET(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: Promise<{ issueId: string; userId: string }> },
 ): Promise<NextResponse> {
   const { issueId, userId } = await params;
@@ -23,8 +23,7 @@ export async function GET(
       role: member.role,
     });
   } catch (error) {
-    console.error('사용자 정보 조회 실패:', error);
-    return createErrorResponse('MEMBER_FETCH_FAILED', 500);
+    return handleApiError(error, 'MEMBER_FETCH_FAILED');
   }
 }
 
@@ -56,7 +55,6 @@ export async function PATCH(
 
     return createSuccessResponse({ success: true });
   } catch (error) {
-    console.error('닉네임 수정 실패:', error);
-    return createErrorResponse('NICKNAME_UPDATE_FAILED', 500);
+    return handleApiError(error, 'NICKNAME_UPDATE_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/members/route.ts
+++ b/src/app/api/issues/[issueId]/members/route.ts
@@ -5,11 +5,11 @@ import { authOptions } from '@/lib/auth';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { findIssueById } from '@/lib/repositories/issue.repository';
 import { broadcast } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { setUserIdCookie } from '@/lib/utils/cookie';
 
 export async function GET(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: Promise<{ issueId: string }> },
 ): Promise<NextResponse> {
   const { issueId: id } = await params;
@@ -31,8 +31,7 @@ export async function GET(
 
     return createSuccessResponse(response);
   } catch (error) {
-    console.error('이슈 조회 실패:', error);
-    return createErrorResponse('MEMBERS_FETCH_FAILED', 500);
+    return handleApiError(error, 'MEMBERS_FETCH_FAILED');
   }
 }
 
@@ -83,8 +82,7 @@ export async function POST(
     }
 
     return createSuccessResponse({ userId: result.userId }, 201);
-  } catch (error: unknown) {
-    console.error('이슈 참여 실패:', error);
-    return createErrorResponse('MEMBER_JOIN_FAILED', 500);
+  } catch (error) {
+    return handleApiError(error, 'MEMBER_JOIN_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/reports/word-cloud/route.ts
+++ b/src/app/api/issues/[issueId]/reports/word-cloud/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { findReportByIssueId } from '@/lib/repositories/report.repository';
 import { findWordCloudsByReportId } from '@/lib/repositories/word-cloud.repository';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 /**
  * 워드클라우드 데이터 조회
  */
-export async function GET(request: NextRequest, { params }: { params: Promise<{ issueId: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ issueId: string }> }) {
   try {
     const { issueId: id } = await params;
 
@@ -21,7 +21,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     return createSuccessResponse({ wordClouds });
   } catch (error) {
-    console.error('워드클라우드 조회 실패:', error);
-    return createErrorResponse('WORD_CLOUD_FETCH_FAILED', 500);
+    return handleApiError(error, 'WORD_CLOUD_FETCH_FAILED');
   }
 }

--- a/src/app/api/issues/[issueId]/route.ts
+++ b/src/app/api/issues/[issueId]/route.ts
@@ -4,7 +4,7 @@ import { findIssueById } from '@/lib/repositories/issue.repository';
 import { issueService } from '@/lib/services/issue.service';
 import { broadcast, broadcastToTopic } from '@/lib/sse/sse-service';
 import { getIssueUserId } from '@/lib/utils/api-auth';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(
   req: NextRequest,
@@ -21,8 +21,7 @@ export async function GET(
 
     return createSuccessResponse(issue);
   } catch (error) {
-    console.error('이슈 조회 실패:', error);
-    return createErrorResponse('ISSUE_FETCH_FAILED', 500);
+    return handleApiError(error, 'ISSUE_FETCH_FAILED');
   }
 }
 

--- a/src/app/api/issues/[issueId]/status/route.ts
+++ b/src/app/api/issues/[issueId]/status/route.ts
@@ -9,7 +9,7 @@ import {
   findIssueTextSourcesForWordCloud,
 } from '@/lib/repositories/word-cloud.repository';
 import { broadcast, broadcastToTopic } from '@/lib/sse/sse-service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { generateWordCloudData } from '@/lib/utils/word-cloud-processor';
 
 export async function PATCH(
@@ -91,7 +91,6 @@ export async function PATCH(
 
     return createSuccessResponse(updatedIssue);
   } catch (error) {
-    console.error('이슈 상태 변경 실패:', error);
-    return createErrorResponse('ISSUE_STATUS_UPDATE_FAILED', 500);
+    return handleApiError(error, 'ISSUE_STATUS_UPDATE_FAILED');
   }
 }

--- a/src/app/api/issues/route.ts
+++ b/src/app/api/issues/route.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { createIssue } from '@/lib/repositories/issue.repository';
 import { createAnonymousUser } from '@/lib/repositories/user.repository';
-import { createErrorResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { createSuccessResponse } from '@/lib/utils/api-helpers';
 import { setUserIdCookie } from '@/lib/utils/cookie';
 
@@ -39,7 +39,6 @@ export async function POST(req: NextRequest) {
 
     return createSuccessResponse(result, 201);
   } catch (error) {
-    console.error('빠른 이슈 생성 실패:', error);
-    return createErrorResponse('ISSUE_CREATE_FAILED', 500);
+    return handleApiError(error, 'ISSUE_CREATE_FAILED');
   }
 }

--- a/src/app/api/projects/[projectId]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[projectId]/members/[memberId]/route.ts
@@ -1,16 +1,13 @@
+import { NextRequest } from 'next/server';
 import { LeaveService } from '@/lib/services/leave.service';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function DELETE(
-  req: Request,
+  req: NextRequest,
   { params }: { params: Promise<{ projectId: string; memberId: string }> },
 ) {
-  const { userId, error } = await getAuthenticatedUserId(req);
-
-  if (!userId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  const userId = requireUserIdFromHeader(req);
 
   try {
     const { projectId } = await params;

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import * as projectRepository from '@/lib/repositories/project.repository';
 import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(
   req: NextRequest,
@@ -20,8 +20,7 @@ export async function GET(
 
     return createSuccessResponse(project, 200);
   } catch (error) {
-    console.error('프로젝트 조회 실패:', error);
-    return createErrorResponse('PROJECT_FETCH_FAILED', 500);
+    return handleApiError(error, 'PROJECT_FETCH_FAILED');
   }
 }
 
@@ -38,7 +37,6 @@ export async function PATCH(
     const project = await projectRepository.updateProject(projectId, title, description);
     return createSuccessResponse(project, 200);
   } catch (error) {
-    console.error('프로젝트 수정 실패:', error);
-    return createErrorResponse('PROJECT_UPDATE_FAILED', 500);
+    return handleApiError(error, 'PROJECT_UPDATE_FAILED');
   }
 }

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,17 +1,13 @@
 import { NextRequest } from 'next/server';
 import * as projectRepository from '@/lib/repositories/project.repository';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ projectId: string }> },
 ) {
-  const { userId, error } = await getAuthenticatedUserId(req);
-
-  if (!userId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  requireUserIdFromHeader(req);
 
   const { projectId } = await params;
 
@@ -33,11 +29,7 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ projectId: string }> },
 ) {
-  const { userId, error } = await getAuthenticatedUserId(req);
-
-  if (!userId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  requireUserIdFromHeader(req);
 
   const { projectId } = await params;
   const { title, description } = await req.json();

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import * as projectRepository from '@/lib/repositories/project.repository';
 import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(req: NextRequest) {
   const ownerId = requireUserIdFromHeader(req);
@@ -11,8 +11,7 @@ export async function GET(req: NextRequest) {
     const projects = await projectRepository.getProjectsByUserMembership(ownerId);
     return createSuccessResponse(projects, 200);
   } catch (error) {
-    console.error('프로젝트 목록 조회 실패:', error);
-    return createErrorResponse('PROJECT_LIST_FAILED', 500);
+    return handleApiError(error, 'PROJECT_LIST_FAILED');
   }
 }
 
@@ -29,8 +28,7 @@ export async function POST(req: NextRequest) {
     const result = await projectRepository.createProject(title, ownerId, description);
     return createSuccessResponse(result, 201);
   } catch (error) {
-    console.error('프로젝트 생성 실패:', error);
-    return createErrorResponse('PROJECT_CREATE_FAILED', 500);
+    return handleApiError(error, 'PROJECT_CREATE_FAILED');
   }
 }
 
@@ -47,7 +45,6 @@ export async function DELETE(req: NextRequest) {
     const result = await projectRepository.deleteProject(id, ownerId);
     return createSuccessResponse(result, 200);
   } catch (error) {
-    console.error('프로젝트 삭제 실패:', error);
-    return createErrorResponse('PROJECT_DELETE_FAILED', 500);
+    return handleApiError(error, 'PROJECT_DELETE_FAILED');
   }
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest } from 'next/server';
 import * as projectRepository from '@/lib/repositories/project.repository';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(req: NextRequest) {
-  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
-
-  if (!ownerId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  const ownerId = requireUserIdFromHeader(req);
 
   try {
     // 참여중인 프로젝트(소유/게스트 포함) 조회
@@ -21,11 +17,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
-
-  if (!ownerId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  const ownerId = requireUserIdFromHeader(req);
 
   const { title, description } = await req.json();
 
@@ -43,11 +35,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
-
-  if (!ownerId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  const ownerId = requireUserIdFromHeader(req);
 
   const { id } = await req.json();
 

--- a/src/app/api/topics/[topicId]/connections/[connectionId]/route.ts
+++ b/src/app/api/topics/[topicId]/connections/[connectionId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function DELETE(
   req: NextRequest,
@@ -20,7 +20,6 @@ export async function DELETE(
 
     return createSuccessResponse(null, 200);
   } catch (error) {
-    console.error('연결 삭제 실패:', error);
-    return createErrorResponse('CONNECTION_DELETE_FAILED', 500);
+    return handleApiError(error, 'CONNECTION_DELETE_FAILED');
   }
 }

--- a/src/app/api/topics/[topicId]/connections/route.ts
+++ b/src/app/api/topics/[topicId]/connections/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(
   _req: NextRequest,
@@ -32,8 +32,7 @@ export async function GET(
 
     return createSuccessResponse(connections, 200);
   } catch (error) {
-    console.error('연결 조회 실패:', error);
-    return createErrorResponse('CONNECTIONS_FETCH_FAILED', 500);
+    return handleApiError(error, 'CONNECTIONS_FETCH_FAILED');
   }
 }
 
@@ -74,7 +73,6 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ top
 
     return createSuccessResponse(connection, 201);
   } catch (error) {
-    console.error('연결 생성 실패:', error);
-    return createErrorResponse('CONNECTION_CREATE_FAILED', 500);
+    return handleApiError(error, 'CONNECTION_CREATE_FAILED');
   }
 }

--- a/src/app/api/topics/[topicId]/issues/route.ts
+++ b/src/app/api/topics/[topicId]/issues/route.ts
@@ -5,7 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { createIssue } from '@/lib/repositories/issue.repository';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
@@ -34,19 +34,15 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ top
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
+  const userId = requireUserIdFromHeader(req);
   const { topicId } = await params;
   const { title } = await req.json();
-
-  const session = await getServerSession(authOptions);
-  const { userId, error } = await getAuthenticatedUserId(req);
-
-  if (!userId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
 
   if (!title) {
     return createErrorResponse('TITLE_REQUIRED', 400);
   }
+
+  const session = await getServerSession(authOptions);
 
   try {
     const issueId = await prisma.$transaction(async (tx) => {

--- a/src/app/api/topics/[topicId]/issues/route.ts
+++ b/src/app/api/topics/[topicId]/issues/route.ts
@@ -6,7 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { createIssue } from '@/lib/repositories/issue.repository';
 import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
   const { topicId } = await params;
@@ -28,8 +28,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ top
 
     return createSuccessResponse(issues, 200);
   } catch (error) {
-    console.error('이슈 조회 실패:', error);
-    return createErrorResponse('ISSUES_FETCH_FAILED', 500);
+    return handleApiError(error, 'ISSUES_FETCH_FAILED');
   }
 }
 
@@ -60,7 +59,6 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ top
 
     return createSuccessResponse({ issueId: issueId }, 201);
   } catch (error) {
-    console.error('토픽 이슈 생성 실패:', error);
-    return createErrorResponse('ISSUE_CREATE_FAILED', 500);
+    return handleApiError(error, 'ISSUE_CREATE_FAILED');
   }
 }

--- a/src/app/api/topics/[topicId]/nodes/[nodeId]/route.ts
+++ b/src/app/api/topics/[topicId]/nodes/[nodeId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function PATCH(
   req: NextRequest,
@@ -26,7 +26,6 @@ export async function PATCH(
 
     return createSuccessResponse(node, 200);
   } catch (error) {
-    console.error('노드 위치 업데이트 실패:', error);
-    return createErrorResponse('NODE_UPDATE_FAILED', 500);
+    return handleApiError(error, 'NODE_UPDATE_FAILED');
   }
 }

--- a/src/app/api/topics/[topicId]/nodes/route.ts
+++ b/src/app/api/topics/[topicId]/nodes/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function GET(
   _req: NextRequest,
@@ -27,7 +27,6 @@ export async function GET(
 
     return createSuccessResponse(nodes, 200);
   } catch (error) {
-    console.error('노드 조회 실패:', error);
-    return createErrorResponse('NODES_FETCH_FAILED', 500);
+    return handleApiError(error, 'NODES_FETCH_FAILED');
   }
 }

--- a/src/app/api/topics/[topicId]/route.ts
+++ b/src/app/api/topics/[topicId]/route.ts
@@ -3,9 +3,9 @@ import { NextRequest } from 'next/server';
 import { authOptions } from '@/lib/auth';
 import { findTopicById } from '@/lib/repositories/topic.repository';
 import { topicService } from '@/lib/services/topic.service';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
-export async function GET(req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
   const { topicId } = await params;
 
   if (!topicId) {
@@ -27,8 +27,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ topi
       updatedAt: topic.updatedAt,
     });
   } catch (error) {
-    console.error('토픽 조회 실패:', error);
-    return createErrorResponse('TOPIC_FETCH_FAILED', 500);
+    return handleApiError(error, 'TOPIC_FETCH_FAILED');
   }
 }
 
@@ -68,7 +67,7 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: Promise<{ topicId: string }> },
 ) {
   const { topicId } = await params;

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest } from 'next/server';
 import * as topicRepository from '@/lib/repositories/topic.repository';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function POST(req: NextRequest) {
-  const { userId, error } = await getAuthenticatedUserId(req);
-
-  if (!userId) {
-    return error ?? createErrorResponse('UNAUTHORIZED', 401);
-  }
+  requireUserIdFromHeader(req);
 
   const { title, projectId } = await req.json();
 

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import * as topicRepository from '@/lib/repositories/topic.repository';
 import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
-import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/utils/api-helpers';
 
 export async function POST(req: NextRequest) {
   requireUserIdFromHeader(req);
@@ -20,7 +20,6 @@ export async function POST(req: NextRequest) {
     const result = await topicRepository.createTopic(title, projectId);
     return createSuccessResponse(result, 201);
   } catch (error) {
-    console.error('토픽 생성 실패:', error);
-    return createErrorResponse('TOPIC_CREATE_FAILED', 500);
+    return handleApiError(error, 'TOPIC_CREATE_FAILED');
   }
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { updateUserWithIssueMemberNickname } from '@/lib/repositories/user.repository';
-import { createSuccessResponse, createErrorResponse } from '@/lib/utils/api-helpers';
+import { createSuccessResponse, createErrorResponse, handleApiError } from '@/lib/utils/api-helpers';
 import { CLIENT_ERROR_MESSAGES } from '@/constants/error-messages';
 
 export async function PATCH(request: Request) {
@@ -25,7 +25,6 @@ export async function PATCH(request: Request) {
 
     return createSuccessResponse(user);
   } catch (error) {
-    console.error('Update user error:', error);
-    return createErrorResponse('INTERNAL_SERVER_ERROR', 500);
+    return handleApiError(error, 'INTERNAL_SERVER_ERROR');
   }
 }

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -2,7 +2,6 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
   // 공통
   API_NOT_FOUND: '요청한 기능을 찾을 수 없습니다. 잠시 후 다시 시도해주세요.',
   PERMISSION_DENIED: '접근 권한이 없습니다.',
-  INTERNAL_ERROR: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
   INTERNAL_SERVER_ERROR: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
   VALIDATION_FAILED: '입력한 값이 올바르지 않습니다. 다시 확인해주세요.',
   UNKNOWN_ERROR: '알 수 없는 오류가 발생했습니다.',

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -3,6 +3,7 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
   API_NOT_FOUND: '요청한 기능을 찾을 수 없습니다. 잠시 후 다시 시도해주세요.',
   PERMISSION_DENIED: '접근 권한이 없습니다.',
   INTERNAL_ERROR: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+  INTERNAL_SERVER_ERROR: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
   VALIDATION_FAILED: '입력한 값이 올바르지 않습니다. 다시 확인해주세요.',
   UNKNOWN_ERROR: '알 수 없는 오류가 발생했습니다.',
   UNAUTHORIZED_USER: '로그인이 필요합니다.',
@@ -10,7 +11,10 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
 
   // 토픽
   TOPIC_NOT_FOUND: '존재하지 않는 토픽입니다.',
+  TOPIC_FETCH_FAILED: '토픽 조회에 실패했습니다.',
+  TOPIC_CREATE_FAILED: '토픽 생성에 실패했습니다.',
   TOPIC_UPDATE_FAILED: '토픽 수정에 실패했습니다.',
+  TOPIC_DELETE_FAILED: '토픽 삭제에 실패했습니다.',
 
   // 카테고리
   CATEGORY_NOT_FOUND: '카테고리를 찾을 수 없습니다.',
@@ -24,8 +28,10 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
   ISSUE_FETCH_FAILED: '이슈 조회에 실패했습니다.',
   ISSUE_CREATE_FAILED: '이슈 생성에 실패했습니다.',
   ISSUE_UPDATE_FAILED: '이슈 수정에 실패했습니다.',
+  ISSUE_DELETE_FAILED: '이슈 삭제에 실패했습니다.',
   ISSUE_STATUS_UPDATE_FAILED: '이슈 상태 변경에 실패했습니다.',
   INVALID_ISSUE_STATUS: '유효하지 않은 이슈 상태입니다.',
+  ISSUES_FETCH_FAILED: '이슈 목록 조회에 실패했습니다.',
   NICKNAME_AND_TITLE_REQUIRED: 'nickname과 title은 필수입니다.',
   SELECTED_IDEA_ID_REQUIRED: '선택된 아이디어 ID가 필요합니다.',
   IDEA_SELECTION_BROADCAST_FAILED: '아이디어 선택 알림에 실패했습니다.',
@@ -37,9 +43,17 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
   MEMBER_FETCH_FAILED: '사용자 정보 조회에 실패했습니다.',
   MEMBER_JOIN_FAILED: '이슈 참여에 실패했습니다.',
   NICKNAME_REQUIRED: 'nickname은 필수입니다.',
+  NICKNAME_UPDATE_FAILED: '닉네임 수정에 실패했습니다.',
   NICKNAME_GENERATION_FAILED: '닉네임 생성에 실패했습니다.',
   USER_ID_REQUIRED: 'User ID가 필요합니다.',
   OWNER_PERMISSION_REQUIRED: '방장 권한이 필요합니다.',
+
+  // 프로젝트
+  PROJECT_LIST_FAILED: '프로젝트 목록 조회에 실패했습니다.',
+  PROJECT_FETCH_FAILED: '프로젝트 조회에 실패했습니다.',
+  PROJECT_CREATE_FAILED: '프로젝트 생성에 실패했습니다.',
+  PROJECT_UPDATE_FAILED: '프로젝트 수정에 실패했습니다.',
+  PROJECT_DELETE_FAILED: '프로젝트 삭제에 실패했습니다.',
 
   // 프로젝트 초대
   INVITATION_NOT_FOUND: '유효하지 않은 초대 링크입니다.',
@@ -55,6 +69,13 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
   INVALID_AI_CATEGORIES: 'AI 카테고리 데이터가 유효하지 않습니다.',
   AI_CATEGORIZATION_FAILED: 'AI 카테고리화에 실패했습니다.',
 
+  // 댓글
+  COMMENT_FETCH_FAILED: '댓글 조회에 실패했습니다.',
+  COMMENT_CREATE_FAILED: '댓글 생성에 실패했습니다.',
+  COMMENT_UPDATE_FAILED: '댓글 수정에 실패했습니다.',
+  COMMENT_DELETE_FAILED: '댓글 삭제에 실패했습니다.',
+  COMMENT_NOT_FOUND: '댓글을 찾을 수 없습니다.',
+
   // 아이디어
   IDEA_DETAIL_FETCH_FAILED: '아이디어 상세 조회에 실패했습니다.',
   IDEA_NOT_FOUND: '아이디어를 찾을 수 없습니다.',
@@ -67,6 +88,16 @@ export const CLIENT_ERROR_MESSAGES: Record<string, string> = {
   // 투표
   INVALID_VOTE_REQUEST: '잘못된 투표 요청입니다.',
   VOTE_FAILED: '투표 처리 중 오류가 발생했습니다.',
+
+  // 연결 / 노드
+  CONNECTIONS_FETCH_FAILED: '연결 조회에 실패했습니다.',
+  CONNECTION_CREATE_FAILED: '연결 생성에 실패했습니다.',
+  CONNECTION_DELETE_FAILED: '연결 삭제에 실패했습니다.',
+  NODES_FETCH_FAILED: '노드 조회에 실패했습니다.',
+  NODE_UPDATE_FAILED: '노드 위치 업데이트에 실패했습니다.',
+
+  // 인증
+  GET_PROVIDERS_ERROR: '인증 공급자 조회에 실패했습니다.',
 
   // 리포트
   REPORT_NOT_FOUND: '리포트를 찾을 수 없습니다.',

--- a/src/hooks/comments/use-comment-mutations.ts
+++ b/src/hooks/comments/use-comment-mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { type Comment, createComment, deleteComment, updateComment } from '@/lib/api/comment';
 import { getCommentQueryKey } from './use-comment-query';
+import { queryKeys } from '@/lib/query-keys';
 
 interface CreateCommentParams {
   userId: string;
@@ -29,7 +30,7 @@ export const useCommentMutations = (issueId: string, ideaId: string) => {
     onSuccess: (created) => {
       queryClient.setQueryData<Comment[]>(commentQueryKey, (prev) => [...(prev ?? []), created]);
       // 아이디어 쿼리 갱신하여 댓글 개수 업데이트
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas', ideaId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideaComments(issueId, ideaId) });
     },
   });
 
@@ -55,7 +56,7 @@ export const useCommentMutations = (issueId: string, ideaId: string) => {
         (prev ?? []).filter((comment) => comment.id !== variables.commentId),
       );
       // 아이디어 쿼리 갱신하여 댓글 개수 업데이트
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas', ideaId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideaComments(issueId, ideaId) });
     },
   });
 

--- a/src/hooks/comments/use-comment-mutations.ts
+++ b/src/hooks/comments/use-comment-mutations.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { type Comment, createComment, deleteComment, updateComment } from '@/lib/api/comment';
-import { getCommentQueryKey } from './use-comment-query';
 import { queryKeys } from '@/lib/query-keys';
+import { getCommentQueryKey } from './use-comment-query';
 
 interface CreateCommentParams {
   userId: string;
@@ -30,7 +30,7 @@ export const useCommentMutations = (issueId: string, ideaId: string) => {
     onSuccess: (created) => {
       queryClient.setQueryData<Comment[]>(commentQueryKey, (prev) => [...(prev ?? []), created]);
       // 아이디어 쿼리 갱신하여 댓글 개수 업데이트
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideaComments(issueId, ideaId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideaDetail(issueId, ideaId) });
     },
   });
 
@@ -56,7 +56,7 @@ export const useCommentMutations = (issueId: string, ideaId: string) => {
         (prev ?? []).filter((comment) => comment.id !== variables.commentId),
       );
       // 아이디어 쿼리 갱신하여 댓글 개수 업데이트
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideaComments(issueId, ideaId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideaDetail(issueId, ideaId) });
     },
   });
 

--- a/src/hooks/comments/use-comment-query.ts
+++ b/src/hooks/comments/use-comment-query.ts
@@ -1,12 +1,10 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchComments } from '@/lib/api/comment';
+import { queryKeys } from '@/lib/query-keys';
 
-export const getCommentQueryKey = (issueId: string, ideaId: string) => [
-  'comments',
-  issueId,
-  ideaId,
-];
+export const getCommentQueryKey = (issueId: string, ideaId: string) =>
+  queryKeys.comments.list(issueId, ideaId);
 
 export const useCommentQuery = (issueId: string, ideaId: string) => {
   const commentQueryKey = useMemo(() => getCommentQueryKey(issueId, ideaId), [ideaId, issueId]);

--- a/src/hooks/invitation/use-invitation-mutation.ts
+++ b/src/hooks/invitation/use-invitation-mutation.ts
@@ -8,14 +8,12 @@ export const useInvitationMutations = (projectId: string) => {
   const router = useRouter();
 
   const createToken = useMutation({
+    meta: { errorLabel: '초대 링크 생성 실패', errorMessage: '초대 링크를 생성할 수 없습니다.' },
     mutationFn: (emails: string[]) => createInvitation(projectId, emails),
-
-    onError: (err) => {
-      toast.error('초대 링크를 생성할 수 없습니다.');
-    },
   });
 
   const joinProject = useMutation({
+    meta: { errorLabel: '초대 참여 실패' },
     mutationFn: (token: string) => acceptInvitation(projectId, token),
 
     onSuccess: () => {
@@ -24,7 +22,6 @@ export const useInvitationMutations = (projectId: string) => {
     },
 
     onError: (err) => {
-      toast.error(err.message);
       if (err.message === CLIENT_ERROR_MESSAGES['ALREADY_EXISTED']) {
         router.push(`/projects/${projectId}`);
       }

--- a/src/hooks/issues/use-ai-structure-mutation.ts
+++ b/src/hooks/issues/use-ai-structure-mutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { categorizeIdeas } from '@/lib/api/issue';
 import { IdeaWithPosition } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 export function useAIStructuringMutation(issueId: string) {
   const queryClient = useQueryClient();
@@ -11,13 +12,13 @@ export function useAIStructuringMutation(issueId: string) {
     meta: { errorLabel: 'AI 구조화 오류' },
     mutationFn: () => categorizeIdeas(issueId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'categories'] });
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.categories(issueId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
     },
   });
 
   const handleAIStructure = () => {
-    const cachedData = queryClient.getQueryData<IdeaWithPosition[]>(['issues', issueId, 'ideas']);
+    const cachedData = queryClient.getQueryData<IdeaWithPosition[]>(queryKeys.issues.ideas(issueId));
     const ideas = cachedData || [];
 
     const validIdeas = ideas.filter((idea) => idea.content.trim().length > 0);

--- a/src/hooks/issues/use-ai-structure-mutation.ts
+++ b/src/hooks/issues/use-ai-structure-mutation.ts
@@ -8,14 +8,11 @@ export function useAIStructuringMutation(issueId: string) {
 
   const categorize = useMutation({
     mutationKey: ['ai-structuring', issueId],
+    meta: { errorLabel: 'AI 구조화 오류' },
     mutationFn: () => categorizeIdeas(issueId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'categories'] });
       queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
-    },
-
-    onError: (err) => {
-      console.error('AI 구조화 오류:', err);
     },
   });
 

--- a/src/hooks/issues/use-category-mutation.ts
+++ b/src/hooks/issues/use-category-mutation.ts
@@ -3,6 +3,7 @@ import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { CLIENT_ERROR_MESSAGES } from '@/constants/error-messages';
 import { createCategory, deleteCategory, updateCategory } from '@/lib/api/category';
 import type { Category } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 interface CategoryPayload {
   title: string;
@@ -14,7 +15,7 @@ interface CategoryPayload {
 
 export const useCategoryMutations = (issueId: string) => {
   const queryClient = useQueryClient();
-  const queryKey = ['issues', issueId, 'categories'];
+  const queryKey = queryKeys.issues.categories(issueId);
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   const create = useMutation({

--- a/src/hooks/issues/use-category-mutation.ts
+++ b/src/hooks/issues/use-category-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { CLIENT_ERROR_MESSAGES } from '@/constants/error-messages';
 import { createCategory, deleteCategory, updateCategory } from '@/lib/api/category';
@@ -19,6 +18,7 @@ export const useCategoryMutations = (issueId: string) => {
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   const create = useMutation({
+    meta: { errorLabel: '카테고리 생성 실패' },
     mutationFn: async (payload: CategoryPayload) => {
       const categories = queryClient.getQueryData<Category[]>(queryKey);
       if (categories?.some((c) => c.title === payload.title)) {
@@ -27,16 +27,13 @@ export const useCategoryMutations = (issueId: string) => {
       return createCategory(issueId, payload, connectionId);
     },
 
-    onError: (_err) => {
-      toast.error(_err.message);
-    },
-
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
     },
   });
 
   const update = useMutation({
+    meta: { errorLabel: '카테고리 수정 실패' },
     mutationFn: ({
       categoryId,
       payload,
@@ -53,21 +50,14 @@ export const useCategoryMutations = (issueId: string) => {
       return updateCategory(issueId, categoryId, payload, connectionId);
     },
 
-    onError: (err) => {
-      toast.error(err.message);
-    },
-
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
     },
   });
 
   const remove = useMutation({
+    meta: { errorLabel: '카테고리 삭제 실패' },
     mutationFn: (categoryId: string) => deleteCategory(issueId, categoryId, connectionId),
-
-    onError: (err) => {
-      toast.error(err.message);
-    },
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });

--- a/src/hooks/issues/use-category-query.ts
+++ b/src/hooks/issues/use-category-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchCategories } from '@/lib/api/category';
 import type { Category, Position } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 interface UICategory {
   id: string;
@@ -11,7 +12,7 @@ interface UICategory {
 
 export const useCategoryQuery = (issueId: string) => {
   return useQuery({
-    queryKey: ['issues', issueId, 'categories'],
+    queryKey: queryKeys.issues.categories(issueId),
     queryFn: () => fetchCategories(issueId),
     staleTime: 1000 * 10,
     select: (data: Category[]): UICategory[] =>

--- a/src/hooks/issues/use-idea-mutation.ts
+++ b/src/hooks/issues/use-idea-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import type { IdeaWithPosition } from '@/issues/types';
 import {
@@ -36,6 +35,7 @@ export const useIdeaMutations = (issueId: string) => {
 
   // 아이디어 생성
   const createMutation = useMutation({
+    meta: { errorLabel: '아이디어 생성 실패' },
     mutationFn: async (data: CreateIdeaRequest) => {
       return createIdeaAPI(issueId, data, connectionId);
     },
@@ -47,14 +47,11 @@ export const useIdeaMutations = (issueId: string) => {
         return [...old, transformedIdea];
       });
     },
-
-    onError: (err) => {
-      toast.error(err.message);
-    },
   });
 
   // 아이디어 수정 (위치, 카테고리)
   const updateMutation = useMutation({
+    meta: { errorLabel: '아이디어 수정 실패' },
     mutationFn: async ({
       ideaId,
       positionX,
@@ -111,10 +108,7 @@ export const useIdeaMutations = (issueId: string) => {
 
       return { previousIdeas };
     },
-    onError: (error, variables, context) => {
-      console.error('아이디어 수정 실패:', error);
-      toast.error(error.message);
-      // 에러 시 롤백
+    onError: (_error, _variables, context) => {
       if (context?.previousIdeas) {
         queryClient.setQueryData(['issues', issueId, 'ideas'], context.previousIdeas);
       }
@@ -128,6 +122,7 @@ export const useIdeaMutations = (issueId: string) => {
 
   // 아이디어 삭제
   const removeMutation = useMutation({
+    meta: { errorLabel: '아이디어 삭제 실패' },
     mutationFn: async (ideaId: string) => {
       return deleteIdeaAPI(issueId, ideaId, connectionId);
     },
@@ -152,10 +147,7 @@ export const useIdeaMutations = (issueId: string) => {
 
       return { previousIdeas };
     },
-    onError: (error, variables, context) => {
-      console.error('아이디어 삭제 실패:', error);
-      toast.error(error.message);
-      // 에러 시 롤백
+    onError: (_error, _variables, context) => {
       if (context?.previousIdeas) {
         queryClient.setQueryData(['issues', issueId, 'ideas'], context.previousIdeas);
       }

--- a/src/hooks/issues/use-idea-mutation.ts
+++ b/src/hooks/issues/use-idea-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import type { IdeaWithPosition } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 import {
   createIdea as createIdeaAPI,
   deleteIdea as deleteIdeaAPI,
@@ -43,7 +44,7 @@ export const useIdeaMutations = (issueId: string) => {
     onSuccess: (newIdea) => {
       // 서버 응답을 IdeaWithPosition으로 변환하여 캐시에 추가
       const transformedIdea = transformIdeaToIdeaWithPosition(newIdea);
-      queryClient.setQueryData<IdeaWithPosition[]>(['issues', issueId, 'ideas'], (old = []) => {
+      queryClient.setQueryData<IdeaWithPosition[]>(queryKeys.issues.ideas(issueId), (old = []) => {
         return [...old, transformedIdea];
       });
     },
@@ -67,7 +68,7 @@ export const useIdeaMutations = (issueId: string) => {
     },
     onMutate: async ({ ideaId, positionX, positionY, categoryId }) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.issues.ideas(issueId) });
 
       // 이전 데이터 스냅샷 저장
       const previousIdeas = queryClient.getQueryData<IdeaWithPosition[]>([
@@ -80,7 +81,7 @@ export const useIdeaMutations = (issueId: string) => {
       // 당장은 필요 없을 수도 있지만, 추후 개선 가능성을 위해 구현
       if (previousIdeas) {
         queryClient.setQueryData<IdeaWithPosition[]>(
-          ['issues', issueId, 'ideas'],
+          queryKeys.issues.ideas(issueId),
           previousIdeas.map((idea) => {
             if (idea.id !== ideaId) return idea;
 
@@ -110,13 +111,13 @@ export const useIdeaMutations = (issueId: string) => {
     },
     onError: (_error, _variables, context) => {
       if (context?.previousIdeas) {
-        queryClient.setQueryData(['issues', issueId, 'ideas'], context.previousIdeas);
+        queryClient.setQueryData(queryKeys.issues.ideas(issueId), context.previousIdeas);
       }
     },
     // 성공하든, 실패하든 무조건 실행
     // 낙관적 업데이트 적용시 서버 상태를 한 번 더 확인
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
     },
   });
 
@@ -128,7 +129,7 @@ export const useIdeaMutations = (issueId: string) => {
     },
     onMutate: async (ideaId) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.issues.ideas(issueId) });
 
       // 이전 데이터 스냅샷 저장
       const previousIdeas = queryClient.getQueryData<IdeaWithPosition[]>([
@@ -140,7 +141,7 @@ export const useIdeaMutations = (issueId: string) => {
       // 낙관적 업데이트로 즉시 제거
       if (previousIdeas) {
         queryClient.setQueryData<IdeaWithPosition[]>(
-          ['issues', issueId, 'ideas'],
+          queryKeys.issues.ideas(issueId),
           previousIdeas.filter((idea) => idea.id !== ideaId),
         );
       }
@@ -149,11 +150,11 @@ export const useIdeaMutations = (issueId: string) => {
     },
     onError: (_error, _variables, context) => {
       if (context?.previousIdeas) {
-        queryClient.setQueryData(['issues', issueId, 'ideas'], context.previousIdeas);
+        queryClient.setQueryData(queryKeys.issues.ideas(issueId), context.previousIdeas);
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
     },
   });
 

--- a/src/hooks/issues/use-idea-query.ts
+++ b/src/hooks/issues/use-idea-query.ts
@@ -2,11 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import type { IdeaWithPosition } from '@/issues/types';
 import type { SimpleIdea } from '@/issues/types';
 import { fetchIdeas } from '@/lib/api/idea';
+import { queryKeys } from '@/lib/query-keys';
 
 // 이슈의 아이디어 목록 조회 (SimpleIdea -> IdeaWithPosition)
 export const useIssueIdeaQuery = (issueId: string) => {
   return useQuery({
-    queryKey: ['issues', issueId, 'ideas'],
+    queryKey: queryKeys.issues.ideas(issueId),
     queryFn: async () => {
       const fetchedIdeas: SimpleIdea[] = await fetchIdeas(issueId);
 

--- a/src/hooks/issues/use-issue-member-mutation.ts
+++ b/src/hooks/issues/use-issue-member-mutation.ts
@@ -10,16 +10,12 @@ export const useIssueMemberMutations = (issueId: string) => {
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   const create = useMutation({
+    meta: { errorLabel: '이슈 참여 실패' },
     mutationFn: async (nickname: string) => await joinIssue(issueId, nickname, connectionId),
 
     onSuccess: (issueMember) => {
       setUserIdForIssue(issueId, issueMember.userId);
       queryClient.invalidateQueries({ queryKey });
-    },
-
-    onError: (error) => {
-      console.error('이슈 참여 실패:', error);
-      toast.error(error.message);
     },
   });
 
@@ -28,12 +24,8 @@ export const useIssueMemberMutations = (issueId: string) => {
 
 export const useNicknameMutations = (issueId: string) => {
   const create = useMutation({
+    meta: { errorLabel: '닉네임 생성 실패' },
     mutationFn: () => generateNickname(issueId),
-
-    onError: (error) => {
-      console.error('닉네임 생성 실패:', error);
-      toast.error(error.message);
-    },
   });
 
   return { generate: create };
@@ -44,6 +36,7 @@ export const useUpdateNicknameMutation = (issueId: string, userId: string) => {
   const queryKey = ['issues', issueId, 'members'];
 
   const update = useMutation({
+    meta: { errorLabel: '닉네임 수정 실패', disableGlobalToast: true },
     mutationFn: (nickname: string) => updateIssueMemberNickname(issueId, userId, nickname),
 
     onSuccess: () => {
@@ -52,8 +45,6 @@ export const useUpdateNicknameMutation = (issueId: string, userId: string) => {
     },
 
     onError: (error) => {
-      console.error('닉네임 수정 실패:', error);
-      // 에러 메시지 처리 (예: 중복 닉네임)
       if (error.message === 'NICKNAME_ALREADY_EXISTS') {
         toast.error('이미 존재하는 닉네임입니다.');
       } else {

--- a/src/hooks/issues/use-issue-member-mutation.ts
+++ b/src/hooks/issues/use-issue-member-mutation.ts
@@ -3,10 +3,11 @@ import toast from 'react-hot-toast';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { generateNickname, joinIssue, updateIssueMemberNickname } from '@/lib/api/issue';
 import { setUserIdForIssue } from '@/lib/storage/issue-user-storage';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useIssueMemberMutations = (issueId: string) => {
   const queryClient = useQueryClient();
-  const queryKey = ['issues', issueId, 'members'];
+  const queryKey = queryKeys.issues.members(issueId);
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   const create = useMutation({
@@ -33,7 +34,7 @@ export const useNicknameMutations = (issueId: string) => {
 
 export const useUpdateNicknameMutation = (issueId: string, userId: string) => {
   const queryClient = useQueryClient();
-  const queryKey = ['issues', issueId, 'members'];
+  const queryKey = queryKeys.issues.members(issueId);
 
   const update = useMutation({
     meta: { errorLabel: '닉네임 수정 실패', disableGlobalToast: true },

--- a/src/hooks/issues/use-issue-member-query.ts
+++ b/src/hooks/issues/use-issue-member-query.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getIssueMembers } from '@/lib/api/issue';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useIssueMemberQuery = (issueId: string, enabled: boolean = true) => {
   return useQuery({
-    queryKey: ['issues', issueId, 'members'],
+    queryKey: queryKeys.issues.members(issueId),
     queryFn: () => getIssueMembers(issueId),
     enabled: enabled && !!issueId,
   });

--- a/src/hooks/issues/use-issue-mutation.ts
+++ b/src/hooks/issues/use-issue-mutation.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/api/issue';
 import { setUserIdForIssue } from '@/lib/storage/issue-user-storage';
 import { IssueStatus } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 interface DbIssue {
   id: string;
@@ -34,7 +35,7 @@ export const useQuickStartMutation = () => {
 
 export const useIssueStatusMutations = (issueId: string) => {
   const queryClient = useQueryClient();
-  const queryKey = ['issues', issueId];
+  const queryKey = queryKeys.issues.detail(issueId);
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   const update = useMutation({
@@ -109,10 +110,10 @@ export const useCreateIssueInTopicMutation = () => {
     onSuccess: (newIssue, variables) => {
       // 토픽의 이슈 목록 캐시 무효화
       queryClient.invalidateQueries({
-        queryKey: ['topics', variables.topicId, 'issues'],
+        queryKey: queryKeys.topics.issues(variables.topicId),
       });
       queryClient.invalidateQueries({
-        queryKey: ['topics', variables.topicId, 'nodes'],
+        queryKey: queryKeys.topics.nodes(variables.topicId),
       });
       toast.success('이슈가 생성되었습니다!');
     },
@@ -129,7 +130,7 @@ export const useUpdateIssueTitleMutation = (issueId: string) => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['issues', issueId],
+        queryKey: queryKeys.issues.detail(issueId),
       });
       toast.success('이슈를 수정했습니다!');
     },
@@ -145,12 +146,12 @@ export const useDeleteIssueMutation = (issueId: string) => {
     mutationFn: (data: { connectionId?: string }) => deleteIssue(issueId, data.connectionId),
 
     onSuccess: async (data) => {
-      await queryClient.cancelQueries({ queryKey: ['issues', issueId] });
-      queryClient.removeQueries({ queryKey: ['issues', issueId] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.issues.detail(issueId) });
+      queryClient.removeQueries({ queryKey: queryKeys.issues.detail(issueId) });
 
       if (data.topicId) {
         queryClient.invalidateQueries({
-          queryKey: ['topics', data.topicId],
+          queryKey: queryKeys.topics.detail(data.topicId),
         });
       }
 

--- a/src/hooks/issues/use-issue-mutation.ts
+++ b/src/hooks/issues/use-issue-mutation.ts
@@ -21,17 +21,13 @@ interface DbIssue {
 
 export const useQuickStartMutation = () => {
   return useMutation({
+    meta: { errorLabel: '이슈 시작 실패' },
     mutationFn: (data: { title: string; nickname: string }) =>
       createQuickIssue(data.title, data.nickname),
 
     onSuccess: (newIssue) => {
       // 이슈별로 userId 저장
       setUserIdForIssue(newIssue.issueId, newIssue.userId);
-    },
-
-    onError: (error) => {
-      console.error(error);
-      toast.error(error.message);
     },
   });
 };
@@ -42,6 +38,7 @@ export const useIssueStatusMutations = (issueId: string) => {
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   const update = useMutation({
+    meta: { errorLabel: '이슈 상태 변경 실패' },
     mutationFn: async (nextStatus: IssueStatus) => {
       await updateIssueStatus(issueId, nextStatus, undefined, undefined, connectionId);
       return nextStatus;
@@ -61,11 +58,10 @@ export const useIssueStatusMutations = (issueId: string) => {
       return { previousIssue };
     },
 
-    onError: (err, _variables, context) => {
+    onError: (_err, _variables, context) => {
       if (context?.previousIssue) {
         queryClient.setQueryData(queryKey, context.previousIssue);
       }
-      toast.error(err.message);
     },
 
     onSettled: () => {
@@ -74,6 +70,7 @@ export const useIssueStatusMutations = (issueId: string) => {
   });
 
   const close = useMutation({
+    meta: { errorLabel: '이슈 종료 실패' },
     mutationFn: async () => {
       await updateIssueStatus(issueId, ISSUE_STATUS.CLOSE, undefined, undefined, connectionId);
     },
@@ -81,11 +78,6 @@ export const useIssueStatusMutations = (issueId: string) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey });
       toast.success('이슈가 종료되었습니다.');
-    },
-
-    onError: (error) => {
-      console.error('이슈 종료 실패:', error);
-      toast.error(error.message);
     },
   });
 
@@ -110,6 +102,7 @@ export const useCreateIssueInTopicMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '이슈 생성 실패', errorMessage: '이슈 생성에 실패했습니다.' },
     mutationFn: (data: { topicId: string; title: string }) =>
       createIssueInTopic(data.topicId, data.title),
 
@@ -123,10 +116,6 @@ export const useCreateIssueInTopicMutation = () => {
       });
       toast.success('이슈가 생성되었습니다!');
     },
-
-    onError: (error: Error) => {
-      toast.error(error.message || '이슈 생성에 실패했습니다.');
-    },
   });
 };
 
@@ -134,6 +123,7 @@ export const useUpdateIssueTitleMutation = (issueId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '이슈 수정 실패', errorMessage: '이슈 수정에 실패했습니다.' },
     mutationFn: (data: { title: string; connectionId?: string }) =>
       updateIssueTitle(issueId, data.title, data.connectionId),
 
@@ -143,10 +133,6 @@ export const useUpdateIssueTitleMutation = (issueId: string) => {
       });
       toast.success('이슈를 수정했습니다!');
     },
-
-    onError: (error: Error) => {
-      toast.error(error.message || '이슈 수정에 실패했습니다.');
-    },
   });
 };
 
@@ -155,6 +141,7 @@ export const useDeleteIssueMutation = (issueId: string) => {
   const router = useRouter();
 
   return useMutation({
+    meta: { errorLabel: '이슈 삭제 실패', errorMessage: '이슈 삭제에 실패했습니다.' },
     mutationFn: (data: { connectionId?: string }) => deleteIssue(issueId, data.connectionId),
 
     onSuccess: async (data) => {
@@ -170,11 +157,6 @@ export const useDeleteIssueMutation = (issueId: string) => {
       toast.success('이슈를 삭제했습니다.');
 
       router.push(data.topicId ? `/topics/${data.topicId}` : '/');
-    },
-
-    onError: (error: Error) => {
-      console.error('이슈 삭제 실패:', error);
-      toast.error(error.message || '이슈 삭제에 실패했습니다.');
     },
   });
 };

--- a/src/hooks/issues/use-issue-query.ts
+++ b/src/hooks/issues/use-issue-query.ts
@@ -2,10 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getIssue } from '@/lib/api/issue';
 import { getTopicIssues } from '@/lib/api/issue-map';
 import { ApiError } from '@/lib/utils/api-response';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useIssueQuery = (issueId: string, enabled: boolean = true) => {
   return useQuery({
-    queryKey: ['issues', issueId],
+    queryKey: queryKeys.issues.detail(issueId),
     queryFn: () => getIssue(issueId),
     enabled: enabled && !!issueId,
     retry: (failureCount, error) => {
@@ -17,7 +18,7 @@ export const useIssueQuery = (issueId: string, enabled: boolean = true) => {
 
 export const useTopicIssuesQuery = (topicId: string | null | undefined) => {
   return useQuery({
-    queryKey: ['topics', topicId, 'issues'],
+    queryKey: queryKeys.topics.issues(topicId!),
     queryFn: () => getTopicIssues(topicId!),
     enabled: !!topicId,
   });

--- a/src/hooks/issues/use-selected-idea-mutation.ts
+++ b/src/hooks/issues/use-selected-idea-mutation.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { selectIdea as selectIdeaAPI } from '@/lib/api/issue';
-import { selectedIdeaQueryKey } from './use-selected-idea-query';
+import { queryKeys } from '@/lib/query-keys';
 
 export function useSelectedIdeaMutation(issueId: string) {
   const queryClient = useQueryClient();
-  const queryKey = selectedIdeaQueryKey(issueId);
+  const queryKey = queryKeys.issues.selectedIdea(issueId);
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   return useMutation({

--- a/src/hooks/issues/use-selected-idea-mutation.ts
+++ b/src/hooks/issues/use-selected-idea-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { selectIdea as selectIdeaAPI } from '@/lib/api/issue';
 import { selectedIdeaQueryKey } from './use-selected-idea-query';
@@ -10,6 +9,7 @@ export function useSelectedIdeaMutation(issueId: string) {
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   return useMutation({
+    meta: { errorLabel: '아이디어 선택 실패' },
     mutationFn: (selectedIdeaId: string) => selectIdeaAPI(issueId, selectedIdeaId, connectionId),
     onMutate: async (selectedIdeaId) => {
       await queryClient.cancelQueries({ queryKey });
@@ -17,8 +17,7 @@ export function useSelectedIdeaMutation(issueId: string) {
       queryClient.setQueryData(queryKey, selectedIdeaId);
       return { previousSelectedIdeaId };
     },
-    onError: (error, _selectedIdeaId, context) => {
-      toast.error(error.message);
+    onError: (_error, _selectedIdeaId, context) => {
       if (context?.previousSelectedIdeaId !== undefined) {
         queryClient.setQueryData(queryKey, context.previousSelectedIdeaId);
       }

--- a/src/hooks/issues/use-selected-idea-query.ts
+++ b/src/hooks/issues/use-selected-idea-query.ts
@@ -1,11 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-
-export const selectedIdeaQueryKey = (issueId: string) =>
-  ['issues', issueId, 'selected-idea'] as const;
+import { queryKeys } from '@/lib/query-keys';
 
 export function useSelectedIdeaQuery(issueId: string) {
   return useQuery<string | null>({
-    queryKey: selectedIdeaQueryKey(issueId),
+    queryKey: queryKeys.issues.selectedIdea(issueId),
     queryFn: async () => null,
     enabled: false,
     initialData: null,

--- a/src/hooks/issues/use-vote-mutation.ts
+++ b/src/hooks/issues/use-vote-mutation.ts
@@ -2,10 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { postVote } from '@/lib/api/vote';
 import type { IdeaWithPosition } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useVoteMutation = (issueId: string, ideaId: string) => {
   const queryClient = useQueryClient();
-  const listQueryKey = ['issues', issueId, 'ideas'];
+  const listQueryKey = queryKeys.issues.ideas(issueId);
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   return useMutation({

--- a/src/hooks/issues/use-vote-mutation.ts
+++ b/src/hooks/issues/use-vote-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import { useSseConnectionStore } from '@/issues/store/use-sse-connection-store';
 import { postVote } from '@/lib/api/vote';
 import type { IdeaWithPosition } from '@/issues/types';
@@ -10,6 +9,7 @@ export const useVoteMutation = (issueId: string, ideaId: string) => {
   const connectionId = useSseConnectionStore((state) => state.connectionIds[issueId]);
 
   return useMutation({
+    meta: { errorLabel: '투표 실패' },
     mutationFn: (variables: { userId: string; voteType: 'AGREE' | 'DISAGREE' }) =>
       postVote({ issueId, ideaId, ...variables, connectionId }),
 
@@ -38,8 +38,7 @@ export const useVoteMutation = (issueId: string, ideaId: string) => {
       return { previousIdeas };
     },
 
-    onError: (err, _variables, context) => {
-      toast.error(err.message);
+    onError: (_err, _variables, context) => {
       if (context?.previousIdeas) {
         queryClient.setQueryData(listQueryKey, context.previousIdeas);
       }

--- a/src/hooks/projects/use-project-mutation.ts
+++ b/src/hooks/projects/use-project-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { leaveProject } from '@/lib/api/leave';
 import { createProject, deleteProject, updateProject } from '@/lib/api/project';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useCreateProjectMutation = () => {
   const queryClient = useQueryClient();
@@ -11,7 +12,7 @@ export const useCreateProjectMutation = () => {
       createProject(data.title, data.description),
 
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
     },
   });
 };
@@ -24,7 +25,7 @@ export const useDeleteProjectMutation = () => {
     mutationFn: (data: { id: string }) => deleteProject(data.id),
 
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
     },
   });
 };
@@ -38,8 +39,8 @@ export const useUpdateProjectMutation = () => {
       updateProject(data.id, data.title, data.description),
 
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
-      queryClient.invalidateQueries({ queryKey: ['project', variables.id] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(variables.id) });
     },
   });
 };
@@ -53,7 +54,7 @@ export const useLeaveProjectMutation = () => {
       leaveProject(data.projectId, data.memberId),
 
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
     },
   });
 };

--- a/src/hooks/projects/use-project-mutation.ts
+++ b/src/hooks/projects/use-project-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'react-hot-toast';
 import { leaveProject } from '@/lib/api/leave';
 import { createProject, deleteProject, updateProject } from '@/lib/api/project';
 
@@ -7,18 +6,12 @@ export const useCreateProjectMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '프로젝트 생성 실패', errorMessage: '프로젝트 생성에 실패했습니다.' },
     mutationFn: (data: { title: string; description?: string }) =>
       createProject(data.title, data.description),
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-    },
-
-    onError: (error: unknown) => {
-      const errorMessage =
-        error instanceof Error && error.message ? error.message : '프로젝트 생성에 실패했습니다.';
-      console.error('프로젝트 생성 실패:', error);
-      toast.error(errorMessage);
     },
   });
 };
@@ -27,14 +20,11 @@ export const useDeleteProjectMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '프로젝트 삭제 실패', disableGlobalToast: true },
     mutationFn: (data: { id: string }) => deleteProject(data.id),
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-    },
-
-    onError: (error) => {
-      console.error('프로젝트 삭제 실패:', error);
     },
   });
 };
@@ -43,17 +33,13 @@ export const useUpdateProjectMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '프로젝트 수정 실패', errorMessage: '프로젝트 수정에 실패했습니다.' },
     mutationFn: (data: { id: string; title: string; description?: string }) =>
       updateProject(data.id, data.title, data.description),
 
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
       queryClient.invalidateQueries({ queryKey: ['project', variables.id] });
-    },
-
-    onError: (error) => {
-      console.error('프로젝트 수정 실패:', error);
-      toast.error(error.message || '프로젝트 수정에 실패했습니다.');
     },
   });
 };
@@ -62,15 +48,12 @@ export const useLeaveProjectMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '프로젝트 나가기 실패', disableGlobalToast: true },
     mutationFn: (data: { projectId: string; memberId: string }) =>
       leaveProject(data.projectId, data.memberId),
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
-    },
-
-    onError: (error) => {
-      console.error('프로젝트 나가기 실패:', error);
     },
   });
 };

--- a/src/hooks/projects/use-project-mutation.ts
+++ b/src/hooks/projects/use-project-mutation.ts
@@ -20,7 +20,7 @@ export const useDeleteProjectMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    meta: { errorLabel: '프로젝트 삭제 실패', disableGlobalToast: true },
+    meta: { errorLabel: '프로젝트 삭제 실패', errorMessage: '프로젝트 삭제에 실패했습니다.' },
     mutationFn: (data: { id: string }) => deleteProject(data.id),
 
     onSuccess: () => {
@@ -48,7 +48,7 @@ export const useLeaveProjectMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    meta: { errorLabel: '프로젝트 나가기 실패', disableGlobalToast: true },
+    meta: { errorLabel: '프로젝트 나가기 실패', errorMessage: '프로젝트 나가기 실패했습니다.' },
     mutationFn: (data: { projectId: string; memberId: string }) =>
       leaveProject(data.projectId, data.memberId),
 

--- a/src/hooks/projects/use-project-query.ts
+++ b/src/hooks/projects/use-project-query.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getProject, getProjects } from '@/lib/api/project';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useProjectsQuery = (enabled: boolean = true) => {
   return useQuery({
-    queryKey: ['projects'],
+    queryKey: queryKeys.projects.all(),
     queryFn: () => getProjects(),
     enabled,
   });
@@ -11,7 +12,7 @@ export const useProjectsQuery = (enabled: boolean = true) => {
 
 export const useProjectQuery = (projectId: string) => {
   return useQuery({
-    queryKey: ['project', projectId],
+    queryKey: queryKeys.projects.detail(projectId),
     queryFn: () => getProject(projectId),
     enabled: !!projectId,
     staleTime: 1000 * 30,

--- a/src/hooks/topics/use-topic-events.ts
+++ b/src/hooks/topics/use-topic-events.ts
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { SSE_EVENT_TYPES } from '@/constants/sse-events';
+import { queryKeys } from '@/lib/query-keys';
 
 interface UseTopicEventsParams {
   topicId: string;
@@ -66,10 +67,10 @@ export function useTopicEvents({
     eventSource.addEventListener(SSE_EVENT_TYPES.ISSUE_STATUS_CHANGED, (event) => {
       const data = JSON.parse((event as MessageEvent).data);
       // 사이드바 이슈 목록 갱신
-      queryClient.invalidateQueries({ queryKey: ['topics', topicId, 'issues'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.topics.issues(topicId) });
       // 특정 이슈 데이터 갱신
       if (data.issueId) {
-        queryClient.invalidateQueries({ queryKey: ['issues', data.issueId] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(data.issueId) });
       }
     });
 
@@ -80,10 +81,10 @@ export function useTopicEvents({
         return;
       }
 
-      queryClient.invalidateQueries({ queryKey: ['topics', topicId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.topics.detail(topicId) });
 
       if (data.issueId) {
-        queryClient.invalidateQueries({ queryKey: ['issues', data.issueId] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(data.issueId) });
       }
 
       toast.error('이슈가 삭제되었습니다.');

--- a/src/hooks/topics/use-topic-mutation.ts
+++ b/src/hooks/topics/use-topic-mutation.ts
@@ -13,6 +13,7 @@ export const useCreateTopicMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '토픽 생성 실패', errorMessage: '토픽 생성에 실패했습니다.' },
     mutationFn: (data: CreateTopicData) => createTopic(data.title, data.projectId),
 
     onSuccess: (data, variables) => {
@@ -41,11 +42,6 @@ export const useCreateTopicMutation = () => {
 
       return data;
     },
-
-    onError: (error) => {
-      console.error('토픽 생성 실패:', error);
-      toast.error(error.message || '토픽 생성에 실패했습니다.');
-    },
   });
 };
 
@@ -53,6 +49,7 @@ export const useUpdateTopicTitleMutation = (topicId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    meta: { errorLabel: '토픽 수정 실패' },
     mutationFn: (data: { title: string }) => updateTopicTitle(topicId, data.title),
 
     onSuccess: () => {
@@ -62,11 +59,6 @@ export const useUpdateTopicTitleMutation = (topicId: string) => {
 
       toast.success('토픽을 수정했습니다!');
     },
-
-    onError: (error: Error) => {
-      console.error('토픽 수정 실패:', error);
-      toast.error(error.message || '토픽 수정에 실패했습니다.');
-    },
   });
 };
 
@@ -75,6 +67,7 @@ export const useDeleteTopicMutation = (topicId: string) => {
   const router = useRouter();
 
   return useMutation({
+    meta: { errorLabel: '토픽 삭제 실패', errorMessage: '토픽 삭제에 실패했습니다.' },
     mutationFn: () => deleteTopic(topicId),
 
     onSuccess: async (data) => {
@@ -87,11 +80,6 @@ export const useDeleteTopicMutation = (topicId: string) => {
       toast.success('토픽이 삭제되었습니다.');
 
       router.push(`/projects/${data.projectId}`);
-    },
-
-    onError: (error: Error) => {
-      console.error('토픽 삭제 실패:', error);
-      toast.error(error.message || '토픽 삭제에 실패했습니다.');
     },
   });
 };

--- a/src/hooks/topics/use-topic-mutation.ts
+++ b/src/hooks/topics/use-topic-mutation.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
 import { createTopic, deleteTopic, updateTopicTitle } from '@/lib/api/topic';
 import type { ProjectwithTopic } from '@/projects/types';
+import { queryKeys } from '@/lib/query-keys';
 
 interface CreateTopicData {
   title: string;
@@ -17,7 +18,7 @@ export const useCreateTopicMutation = () => {
     mutationFn: (data: CreateTopicData) => createTopic(data.title, data.projectId),
 
     onSuccess: (data, variables) => {
-      queryClient.setQueryData<ProjectwithTopic>(['project', variables.projectId], (prev) => {
+      queryClient.setQueryData<ProjectwithTopic>(queryKeys.projects.detail(variables.projectId), (prev) => {
         if (!prev) {
           return prev;
         }
@@ -54,7 +55,7 @@ export const useUpdateTopicTitleMutation = (topicId: string) => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['topics', topicId],
+        queryKey: queryKeys.topics.detail(topicId),
       });
 
       toast.success('토픽을 수정했습니다!');
@@ -71,10 +72,10 @@ export const useDeleteTopicMutation = (topicId: string) => {
     mutationFn: () => deleteTopic(topicId),
 
     onSuccess: async (data) => {
-      await queryClient.cancelQueries({ queryKey: ['topics', topicId] });
-      queryClient.removeQueries({ queryKey: ['topics', topicId] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.topics.detail(topicId) });
+      queryClient.removeQueries({ queryKey: queryKeys.topics.detail(topicId) });
       queryClient.invalidateQueries({
-        queryKey: ['project', data.projectId],
+        queryKey: queryKeys.projects.detail(data.projectId),
       });
 
       toast.success('토픽이 삭제되었습니다.');

--- a/src/hooks/topics/use-topic-mutations.ts
+++ b/src/hooks/topics/use-topic-mutations.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import {
   createConnection as createConnectionAPI,
   deleteConnection as deleteConnectionAPI,
@@ -12,6 +11,7 @@ export const useTopicMutations = (topicId: string) => {
 
   // 연결 생성
   const createConnectionMutation = useMutation({
+    meta: { errorLabel: '연결 생성 실패', errorMessage: '연결 생성에 실패했습니다.' },
     mutationFn: async (data: {
       sourceIssueId: string;
       targetIssueId: string;
@@ -45,10 +45,7 @@ export const useTopicMutations = (topicId: string) => {
 
       return { previousConnections };
     },
-    onError: (error, variables, context) => {
-      console.error('연결 생성 실패:', error);
-      toast.error('연결 생성에 실패했습니다.');
-      // 에러 시 롤백
+    onError: (_error, _variables, context) => {
       if (context?.previousConnections) {
         queryClient.setQueryData(['topics', topicId, 'connections'], context.previousConnections);
       }
@@ -60,6 +57,7 @@ export const useTopicMutations = (topicId: string) => {
 
   // 연결 삭제
   const deleteConnectionMutation = useMutation({
+    meta: { errorLabel: '연결 삭제 실패', errorMessage: '연결 삭제에 실패했습니다.' },
     mutationFn: async (connectionId: string) => {
       return deleteConnectionAPI(topicId, connectionId);
     },
@@ -84,10 +82,7 @@ export const useTopicMutations = (topicId: string) => {
 
       return { previousConnections };
     },
-    onError: (error, variables, context) => {
-      console.error('연결 삭제 실패:', error);
-      toast.error('연결 삭제에 실패했습니다.');
-      // 에러 시 롤백
+    onError: (_error, _variables, context) => {
       if (context?.previousConnections) {
         queryClient.setQueryData(['topics', topicId, 'connections'], context.previousConnections);
       }
@@ -99,6 +94,7 @@ export const useTopicMutations = (topicId: string) => {
 
   // 노드 위치 업데이트
   const updateNodePositionMutation = useMutation({
+    meta: { errorLabel: '노드 위치 업데이트 실패', errorMessage: '노드 위치 업데이트에 실패했습니다.' },
     mutationFn: async ({
       nodeId,
       positionX,
@@ -134,10 +130,7 @@ export const useTopicMutations = (topicId: string) => {
 
       return { previousNodes };
     },
-    onError: (error, variables, context) => {
-      console.error('노드 위치 업데이트 실패:', error);
-      toast.error('노드 위치 업데이트에 실패했습니다.');
-      // 에러 시 롤백
+    onError: (_error, _variables, context) => {
       if (context?.previousNodes) {
         queryClient.setQueryData(['topics', topicId, 'nodes'], context.previousNodes);
       }

--- a/src/hooks/topics/use-topic-mutations.ts
+++ b/src/hooks/topics/use-topic-mutations.ts
@@ -5,6 +5,7 @@ import {
   updateNodePosition as updateNodePositionAPI,
 } from '@/lib/api/issue-map';
 import type { IssueConnection, IssueNode } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 export const useTopicMutations = (topicId: string) => {
   const queryClient = useQueryClient();
@@ -22,7 +23,7 @@ export const useTopicMutations = (topicId: string) => {
     },
     onMutate: async (newConnection) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['topics', topicId, 'connections'] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.topics.connections(topicId) });
 
       // 이전 데이터 스냅샷 저장
       const previousConnections = queryClient.getQueryData<IssueConnection[]>([
@@ -38,7 +39,7 @@ export const useTopicMutations = (topicId: string) => {
           ...newConnection,
         };
         queryClient.setQueryData<IssueConnection[]>(
-          ['topics', topicId, 'connections'],
+          queryKeys.topics.connections(topicId),
           [...previousConnections, optimisticConnection],
         );
       }
@@ -47,11 +48,11 @@ export const useTopicMutations = (topicId: string) => {
     },
     onError: (_error, _variables, context) => {
       if (context?.previousConnections) {
-        queryClient.setQueryData(['topics', topicId, 'connections'], context.previousConnections);
+        queryClient.setQueryData(queryKeys.topics.connections(topicId), context.previousConnections);
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['topics', topicId, 'connections'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.topics.connections(topicId) });
     },
   });
 
@@ -63,7 +64,7 @@ export const useTopicMutations = (topicId: string) => {
     },
     onMutate: async (connectionId) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['topics', topicId, 'connections'] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.topics.connections(topicId) });
 
       // 이전 데이터 스냅샷 저장
       const previousConnections = queryClient.getQueryData<IssueConnection[]>([
@@ -75,7 +76,7 @@ export const useTopicMutations = (topicId: string) => {
       // 낙관적 업데이트로 즉시 제거
       if (previousConnections) {
         queryClient.setQueryData<IssueConnection[]>(
-          ['topics', topicId, 'connections'],
+          queryKeys.topics.connections(topicId),
           previousConnections.filter((conn) => conn.id !== connectionId),
         );
       }
@@ -84,11 +85,11 @@ export const useTopicMutations = (topicId: string) => {
     },
     onError: (_error, _variables, context) => {
       if (context?.previousConnections) {
-        queryClient.setQueryData(['topics', topicId, 'connections'], context.previousConnections);
+        queryClient.setQueryData(queryKeys.topics.connections(topicId), context.previousConnections);
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['topics', topicId, 'connections'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.topics.connections(topicId) });
     },
   });
 
@@ -108,15 +109,15 @@ export const useTopicMutations = (topicId: string) => {
     },
     onMutate: async ({ nodeId, positionX, positionY }) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['topics', topicId, 'nodes'] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.topics.nodes(topicId) });
 
       // 이전 데이터 스냅샷 저장
-      const previousNodes = queryClient.getQueryData<IssueNode[]>(['topics', topicId, 'nodes']);
+      const previousNodes = queryClient.getQueryData<IssueNode[]>(queryKeys.topics.nodes(topicId));
 
       // 낙관적 업데이트로 즉시 위치 변경
       if (previousNodes) {
         queryClient.setQueryData<IssueNode[]>(
-          ['topics', topicId, 'nodes'],
+          queryKeys.topics.nodes(topicId),
           previousNodes.map((node) => {
             if (node.id !== nodeId) return node;
             return {
@@ -132,11 +133,11 @@ export const useTopicMutations = (topicId: string) => {
     },
     onError: (_error, _variables, context) => {
       if (context?.previousNodes) {
-        queryClient.setQueryData(['topics', topicId, 'nodes'], context.previousNodes);
+        queryClient.setQueryData(queryKeys.topics.nodes(topicId), context.previousNodes);
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['topics', topicId, 'nodes'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.topics.nodes(topicId) });
     },
   });
 

--- a/src/hooks/topics/use-topic-query.ts
+++ b/src/hooks/topics/use-topic-query.ts
@@ -3,6 +3,7 @@ import { getTopicConnections, getTopicIssues, getTopicNodes } from '@/lib/api/is
 import { getTopic } from '@/lib/api/topic';
 import { ApiError } from '@/lib/utils/api-response';
 import type { IssueConnection, IssueMapData, IssueNode } from '@/issues/types';
+import { queryKeys } from '@/lib/query-keys';
 
 // 초기 데이터는 서버 컴포넌트에서 주입하고, invalidateQueries로 갱신
 export const useTopicQuery = (
@@ -12,19 +13,19 @@ export const useTopicQuery = (
   initialConnections: IssueConnection[],
 ) => {
   const issuesQuery = useQuery({
-    queryKey: ['topics', topicId, 'issues'],
+    queryKey: queryKeys.topics.issues(topicId),
     queryFn: () => getTopicIssues(topicId),
     initialData: initialIssues,
   });
 
   const nodesQuery = useQuery({
-    queryKey: ['topics', topicId, 'nodes'],
+    queryKey: queryKeys.topics.nodes(topicId),
     queryFn: () => getTopicNodes(topicId),
     initialData: initialNodes,
   });
 
   const connectionsQuery = useQuery({
-    queryKey: ['topics', topicId, 'connections'],
+    queryKey: queryKeys.topics.connections(topicId),
     queryFn: () => getTopicConnections(topicId),
     initialData: initialConnections,
   });
@@ -40,7 +41,7 @@ export const useTopicQuery = (
 // 토픽 상세 정보 조회
 export const useTopicDetailQuery = (topicId: string) => {
   return useQuery({
-    queryKey: ['topics', topicId],
+    queryKey: queryKeys.topics.detail(topicId),
     queryFn: () => getTopic(topicId),
     staleTime: 1000 * 10,
     retry: (failureCount, error) => {

--- a/src/hooks/user/use-user-mutation.ts
+++ b/src/hooks/user/use-user-mutation.ts
@@ -7,26 +7,20 @@ export const useUserMutation = () => {
   const queryClient = useQueryClient();
 
   const withdrawMutation = useMutation({
+    meta: { errorLabel: '회원탈퇴 에러', errorMessage: '회원탈퇴 중 오류가 발생했습니다.' },
     mutationFn: () => withdraw(),
     onSuccess: async () => {
       toast.success('회원탈퇴가 완료되었습니다.');
       queryClient.clear();
       await signOut({ callbackUrl: '/' });
     },
-    onError: (error: Error) => {
-      console.error('회원탈퇴 에러:', error);
-      toast.error(error.message || '회원탈퇴 중 오류가 발생했습니다.');
-    },
   });
 
   const updateDisplayNameMutation = useMutation({
+    meta: { errorLabel: '이름 변경 에러' },
     mutationFn: (displayName: string) => updateDisplayName(displayName),
     onSuccess: () => {
       toast.success('보여질 이름이 변경되었습니다.');
-    },
-    onError: (error: Error) => {
-      console.error('이름 변경 에러:', error);
-      toast.error(error.message || '이름 변경 중 오류가 발생했습니다.');
     },
   });
 

--- a/src/issues/components/issue-detail-page.tsx
+++ b/src/issues/components/issue-detail-page.tsx
@@ -16,9 +16,10 @@ import { ErrorPage } from '@/components/error/error';
 import LoadingOverlay from '@/components/loading-overlay/loading-overlay';
 import { useModalStore } from '@/components/modal/use-modal-store';
 import { ISSUE_STATUS, ISSUE_STATUS_DESCRIPTION } from '@/constants/issue';
-import { selectedIdeaQueryKey, useIssueQuery, useSelectedIdeaQuery } from '@/hooks/issues';
+import { useIssueQuery, useSelectedIdeaQuery } from '@/hooks/issues';
 import { useProjectsQuery } from '@/hooks/projects';
 import { joinIssueAsLoggedInUser } from '@/lib/api/issue';
+import { queryKeys } from '@/lib/query-keys';
 import { getActiveDiscussionIdeaIds } from '@/lib/utils/active-discussion-idea';
 import IssueJoinModal from './issue-join-modal/issue-join-modal';
 import {
@@ -118,7 +119,7 @@ const IssueDetailPage = () => {
 
       try {
         await joinIssueAsLoggedInUser(issueId, connectionId);
-        queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'members'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.members(issueId) });
       } catch (error) {
         console.error('자동 참여 실패:', error);
       }
@@ -193,7 +194,7 @@ const IssueDetailPage = () => {
   useEffect(() => {
     if (!serverIdeas?.length || !issueId) return;
     const selectedId = serverIdeas.find((i) => i.isSelected)?.id ?? null;
-    queryClient.setQueryData(selectedIdeaQueryKey(issueId), selectedId);
+    queryClient.setQueryData(queryKeys.issues.selectedIdea(issueId), selectedId);
   }, [serverIdeas, issueId, queryClient]);
 
   // 드래그 중인 position을 오버레이

--- a/src/issues/hooks/use-issue-events.ts
+++ b/src/issues/hooks/use-issue-events.ts
@@ -6,8 +6,9 @@ import CloseIssueModal from '@/issues/components/close-issue-modal/close-issue-m
 import { useModalStore } from '@/components/modal/use-modal-store';
 import { ISSUE_STATUS, MEMBER_ROLE } from '@/constants/issue';
 import { SSE_EVENT_TYPES } from '@/constants/sse-events';
-import { selectedIdeaQueryKey, useIssueMemberQuery } from '@/hooks/issues';
+import { useIssueMemberQuery } from '@/hooks/issues';
 import { deleteCloseModal } from '@/lib/api/issue';
+import { queryKeys } from '@/lib/query-keys';
 import { useIssueStore } from '../store/use-issue-store';
 import { useSseConnectionStore } from '../store/use-sse-connection-store';
 import { useIdeasWithTemp } from './use-ideas-with-temp';
@@ -37,7 +38,7 @@ export function useIssueEvents({
   const [error, setError] = useState<Event | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
   const connectionIdRef = useRef<string | null>(null);
-  const selectedIdeaKey = useMemo(() => selectedIdeaQueryKey(issueId), [issueId]);
+  const selectedIdeaKey = useMemo(() => queryKeys.issues.selectedIdea(issueId), [issueId]);
 
   const { setIsAIStructuring } = useIssueStore((state) => state.actions);
   const { setOnlineMemberIds } = useIssueStore((state) => state.actions);
@@ -77,7 +78,7 @@ export function useIssueEvents({
       // 재연결 시 전체 데이터 갱신
       const isReconnect = connectionIdRef.current !== null;
       if (isReconnect) {
-        queryClient.invalidateQueries({ queryKey: ['issues', issueId] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId) });
       }
     };
 
@@ -106,32 +107,32 @@ export function useIssueEvents({
     // 요청이 많아질 수록 안좋긴 한데, tanstack query의 플로우랑 잘 맞음...
     // 만약 SSE에 데이터를 직접 가져와서 setQueryData로 반영하는 방식으로 바꾸게 된다면 이 부분을 수정해야 함
     eventSource.addEventListener(SSE_EVENT_TYPES.IDEA_CREATED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.IDEA_MOVED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.IDEA_DELETED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
     });
 
     // 카테고리 이벤트 핸들러
     eventSource.addEventListener(SSE_EVENT_TYPES.CATEGORY_CREATED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'categories'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.categories(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.CATEGORY_UPDATED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'categories'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.categories(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.CATEGORY_MOVED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'categories'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.categories(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.CATEGORY_DELETED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'categories'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.categories(issueId) });
     });
 
     // AI 구조화 핸들러
@@ -162,7 +163,7 @@ export function useIssueEvents({
         typeof data.disagreeCount !== 'number'
       )
         return;
-      queryClient.setQueryData<IdeaWithPosition[]>(['issues', issueId, 'ideas'], (old) => {
+      queryClient.setQueryData<IdeaWithPosition[]>(queryKeys.issues.ideas(issueId), (old) => {
         if (!Array.isArray(old)) return old;
         return old.map((idea) =>
           idea.id === data.ideaId
@@ -177,17 +178,17 @@ export function useIssueEvents({
       const data = JSON.parse((event as MessageEvent).data);
       // 특정 아이디어의 댓글 목록 및 commentCount 갱신
       if (data.ideaId) {
-        queryClient.invalidateQueries({ queryKey: ['comments', issueId, data.ideaId] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.comments.list(issueId, data.ideaId) });
 
         if (typeof data.commentCount === 'number') {
-          queryClient.setQueryData(['issues', issueId, 'ideas'], (old: any) => {
+          queryClient.setQueryData(queryKeys.issues.ideas(issueId), (old: any) => {
             if (!Array.isArray(old)) return old;
             return old.map((idea) =>
               idea.id === data.ideaId ? { ...idea, commentCount: data.commentCount } : idea,
             );
           });
         } else {
-          queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
         }
       }
     });
@@ -195,7 +196,7 @@ export function useIssueEvents({
     eventSource.addEventListener(SSE_EVENT_TYPES.COMMENT_UPDATED, (event) => {
       const data = JSON.parse((event as MessageEvent).data);
       if (data.ideaId) {
-        queryClient.invalidateQueries({ queryKey: ['comments', issueId, data.ideaId] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.comments.list(issueId, data.ideaId) });
       }
     });
 
@@ -203,17 +204,17 @@ export function useIssueEvents({
       const data = JSON.parse((event as MessageEvent).data);
       // 특정 아이디어의 댓글 목록 및 commentCount 갱신
       if (data.ideaId) {
-        queryClient.invalidateQueries({ queryKey: ['comments', issueId, data.ideaId] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.comments.list(issueId, data.ideaId) });
 
         if (typeof data.commentCount === 'number') {
-          queryClient.setQueryData(['issues', issueId, 'ideas'], (old: any) => {
+          queryClient.setQueryData(queryKeys.issues.ideas(issueId), (old: any) => {
             if (!Array.isArray(old)) return old;
             return old.map((idea) =>
               idea.id === data.ideaId ? { ...idea, commentCount: data.commentCount } : idea,
             );
           });
         } else {
-          queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'ideas'] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.issues.ideas(issueId) });
         }
       }
     });
@@ -221,36 +222,36 @@ export function useIssueEvents({
     // 이슈 변경 이벤트 핸들러
     eventSource.addEventListener(SSE_EVENT_TYPES.ISSUE_STATUS_CHANGED, (event) => {
       const data = JSON.parse((event as MessageEvent).data);
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId) });
       if (data.status === ISSUE_STATUS.CATEGORIZE) {
         deleteTempIdea();
       }
       // 사이드바 이슈 목록도 갱신
       const targetTopicId = data.topicId || topicId;
       if (targetTopicId) {
-        queryClient.invalidateQueries({ queryKey: ['topics', targetTopicId, 'issues'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.topics.issues(targetTopicId) });
       }
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.ISSUE_TITLE_CHANGED, (event) => {
       const data = JSON.parse((event as MessageEvent).data);
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId) });
       // 사이드바 이슈 목록도 갱신
       const targetTopicId = data.topicId || topicId;
       if (targetTopicId) {
-        queryClient.invalidateQueries({ queryKey: ['topics', targetTopicId, 'issues'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.topics.issues(targetTopicId) });
       }
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.ISSUE_DELETED, (event) => {
       const data = JSON.parse((event as MessageEvent).data);
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId) });
 
       const targetTopicId = data.topicId || topicId;
       if (targetTopicId) {
-        queryClient.invalidateQueries({ queryKey: ['topics', targetTopicId, 'issues'] });
-        queryClient.invalidateQueries({ queryKey: ['topics', targetTopicId, 'nodes'] });
-        queryClient.invalidateQueries({ queryKey: ['topics', targetTopicId, 'connections'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.topics.issues(targetTopicId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.topics.nodes(targetTopicId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.topics.connections(targetTopicId) });
       }
 
       toast.error('이슈가 삭제되었습니다.');
@@ -260,15 +261,15 @@ export function useIssueEvents({
 
     // 멤버 이벤트 핸들러
     eventSource.addEventListener(SSE_EVENT_TYPES.MEMBER_JOINED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'members'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.members(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.MEMBER_UPDATED, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'members'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.members(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.MEMBER_LEFT, () => {
-      queryClient.invalidateQueries({ queryKey: ['issues', issueId, 'members'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.members(issueId) });
     });
 
     eventSource.addEventListener(SSE_EVENT_TYPES.MEMBER_PRESENCE, (event) => {
@@ -282,7 +283,7 @@ export function useIssueEvents({
       const data = JSON.parse((event as MessageEvent).data);
       if (!data.ideaId) return;
       queryClient.setQueryData(selectedIdeaKey, data.ideaId);
-      queryClient.setQueryData<IdeaWithPosition[]>(['issues', issueId, 'ideas'], (old) => {
+      queryClient.setQueryData<IdeaWithPosition[]>(queryKeys.issues.ideas(issueId), (old) => {
         if (!Array.isArray(old)) return old;
         return old.map((idea) =>
           idea.id === data.ideaId ? { ...idea, isSelected: true } : { ...idea, isSelected: false },

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -6,8 +6,7 @@ export const queryKeys = {
   issues: {
     detail: (issueId: string) => ['issues', issueId] as const,
     ideas: (issueId: string) => ['issues', issueId, 'ideas'] as const,
-    ideaComments: (issueId: string, ideaId: string) =>
-      ['issues', issueId, 'ideas', ideaId] as const,
+    ideaDetail: (issueId: string, ideaId: string) => ['issues', issueId, 'ideas', ideaId] as const,
     categories: (issueId: string) => ['issues', issueId, 'categories'] as const,
     members: (issueId: string) => ['issues', issueId, 'members'] as const,
     selectedIdea: (issueId: string) => ['issues', issueId, 'selected-idea'] as const,

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,24 @@
+export const queryKeys = {
+  projects: {
+    all: () => ['projects'] as const,
+    detail: (projectId: string) => ['project', projectId] as const,
+  },
+  issues: {
+    detail: (issueId: string) => ['issues', issueId] as const,
+    ideas: (issueId: string) => ['issues', issueId, 'ideas'] as const,
+    ideaComments: (issueId: string, ideaId: string) =>
+      ['issues', issueId, 'ideas', ideaId] as const,
+    categories: (issueId: string) => ['issues', issueId, 'categories'] as const,
+    members: (issueId: string) => ['issues', issueId, 'members'] as const,
+    selectedIdea: (issueId: string) => ['issues', issueId, 'selected-idea'] as const,
+  },
+  topics: {
+    detail: (topicId: string) => ['topics', topicId] as const,
+    issues: (topicId: string) => ['topics', topicId, 'issues'] as const,
+    nodes: (topicId: string) => ['topics', topicId, 'nodes'] as const,
+    connections: (topicId: string) => ['topics', topicId, 'connections'] as const,
+  },
+  comments: {
+    list: (issueId: string, ideaId: string) => ['comments', issueId, ideaId] as const,
+  },
+};

--- a/src/lib/utils/api-auth.ts
+++ b/src/lib/utils/api-auth.ts
@@ -1,37 +1,25 @@
 import { getServerSession } from 'next-auth';
 import { NextRequest } from 'next/server';
 import { authOptions } from '@/lib/auth';
-import { createErrorResponse } from '@/lib/utils/api-helpers';
 import { getUserIdFromServer } from './cookie';
 
-export async function getAuthenticatedUserId(request?: Request | NextRequest) {
-  const headerUserId = request ? getUserIdFromHeader(request) : null;
-
-  if (headerUserId) {
-    return {
-      userId: headerUserId,
-      error: null,
-    };
-  }
-
-  const session = await getServerSession(authOptions);
-
-  if (!session || !session.user || !session.user.id) {
-    return {
-      userId: null,
-      error: createErrorResponse('UNAUTHORIZED', 401),
-    };
-  }
-
-  return {
-    userId: session.user.id,
-    error: null,
-  };
-}
-
-// Middleware에서 설정한 userId 추출
+// proxy.ts(미들웨어)가 인증된 요청에 주입한 x-user-id 헤더를 읽음
 export function getUserIdFromHeader(request: Request | NextRequest): string | null {
   return request.headers.get('x-user-id') || null;
+}
+
+// 인증 필수 라우트용.
+// createErrorResponse 대신 throw를 사용하는 이유:
+//   이 함수는 string을 반환하는 유틸이므로 NextResponse를 반환할 수 없고,
+//   헤더 누락은 사용자 에러가 아니라 proxy.ts matcher 설정 누락(개발자 실수)이다.
+//   정상 운영 중에는 이 분기가 절대 실행되지 않아야 하므로 500으로 즉시 터뜨려 발견하게 한다.
+export function requireUserIdFromHeader(request: Request | NextRequest): string {
+  const userId = getUserIdFromHeader(request);
+  if (!userId) {
+    const url = 'nextUrl' in request ? request.nextUrl.pathname : request.url;
+    throw new Error(`Missing x-user-id header — proxy.ts matcher misconfigured (path: ${url})`);
+  }
+  return userId;
 }
 
 export async function getIssueUserId(issueId: string): Promise<string | null> {

--- a/src/lib/utils/api-helpers.ts
+++ b/src/lib/utils/api-helpers.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { ApiError, ApiSuccess } from '@/types';
+import { CLIENT_ERROR_MESSAGES } from '@/constants/error-messages';
 
 // 성공 응답 생성
 export function createSuccessResponse<T>(data: T, status = 200): NextResponse<ApiSuccess<T>> {
@@ -11,6 +12,13 @@ export function createSuccessResponse<T>(data: T, status = 200): NextResponse<Ap
     },
     { status },
   );
+}
+
+// 단순 catch 블록용: console.error + createErrorResponse 패턴 통합
+export function handleApiError(error: unknown, fallbackCode: string): NextResponse<ApiError> {
+  const logMessage = CLIENT_ERROR_MESSAGES[fallbackCode] ?? fallbackCode;
+  console.error(logMessage, error);
+  return createErrorResponse(fallbackCode, 500);
 }
 
 // 에러 응답 생성

--- a/src/projects/components/project-card/project-card.tsx
+++ b/src/projects/components/project-card/project-card.tsx
@@ -111,9 +111,6 @@ export function ProjectCard({
               toast.success('프로젝트가 삭제되었습니다.');
               router.refresh();
             },
-            onError: () => {
-              toast.error('프로젝트 삭제에 실패했습니다.');
-            },
           },
         );
       }
@@ -135,9 +132,6 @@ export function ProjectCard({
           {
             onSuccess: () => {
               toast.success('프로젝트에서 나갔습니다.');
-            },
-            onError: () => {
-              toast.error('프로젝트 나가기 실패했습니다.');
             },
           },
         );

--- a/src/providers/query-provider.tsx
+++ b/src/providers/query-provider.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import * as React from 'react';
-import { QueryClient, QueryClientProvider, isServer } from '@tanstack/react-query';
+import { MutationCache, QueryClient, QueryClientProvider, isServer } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experimental';
+import toast from 'react-hot-toast';
 
 function makeQueryClient() {
   return new QueryClient({
@@ -12,6 +13,19 @@ function makeQueryClient() {
         staleTime: 60 * 1000,
       },
     },
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        const label = mutation.meta?.errorLabel ?? '[Mutation Error]';
+        console.error(`${label}:`, error);
+
+        if (mutation.meta?.disableGlobalToast) return;
+
+        const message = mutation.meta?.errorMessage
+          || (error instanceof Error ? error.message : null)
+          || '오류가 발생했습니다.';
+        toast.error(message);
+      },
+    }),
   });
 }
 

--- a/src/types/react-query.d.ts
+++ b/src/types/react-query.d.ts
@@ -1,0 +1,11 @@
+import '@tanstack/react-query';
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    mutationMeta: {
+      errorMessage?: string;
+      errorLabel?: string;
+      disableGlobalToast?: boolean;
+    };
+  }
+}

--- a/test/api/projects/[projectId]/members/[memberId]/route.test.ts
+++ b/test/api/projects/[projectId]/members/[memberId]/route.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@test/utils/api-test-helpers';
 import { DELETE } from '@/app/api/projects/[projectId]/members/[memberId]/route';
 import { LeaveService } from '@/lib/services/leave.service';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 
 jest.mock('@auth/prisma-adapter', () => ({
   PrismaAdapter: jest.fn(() => ({})),
@@ -24,7 +24,7 @@ describe('DELETE /api/projects/[projectId]/members/[memberId]', () => {
   const userId = 'user-1';
 
   // Mock 함수 타입 캐스팅
-  const mockedGetAuthenticatedUserId = getAuthenticatedUserId as jest.Mock;
+  const mockedRequireUserIdFromHeader = requireUserIdFromHeader as jest.Mock;
   const mockedLeaveProject = LeaveService.leaveProject as jest.Mock;
 
   // Next.js 15 스타일의 params (Promise)
@@ -33,25 +33,19 @@ describe('DELETE /api/projects/[projectId]/members/[memberId]', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // 기본적으로 인증 성공 상태로 설정
-    mockedGetAuthenticatedUserId.mockResolvedValue({ userId, error: null });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
   });
 
-  it('인증되지 않은 사용자라면 401 에러를 반환한다', async () => {
-    // Given: 인증 실패
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId: null,
-      error: new Response(JSON.stringify({ error: 'UNAUTHORIZED' }), { status: 401 }),
+  it('헤더가 없으면 throw한다', async () => {
+    // Given: proxy 매처 누락 시 throw
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
     });
 
     const req = createMockRequest();
 
-    // When
-    const response = await DELETE(req, { params: mockParams });
-
-    // Then
-    expect(response.status).toBe(401);
-    const data = await response.json();
-    expect(data.error).toBe('UNAUTHORIZED');
+    // When / Then
+    await expect(DELETE(req, { params: mockParams })).rejects.toThrow();
     expect(mockedLeaveProject).not.toHaveBeenCalled();
   });
 

--- a/test/api/projects/[projectId]/route.test.ts
+++ b/test/api/projects/[projectId]/route.test.ts
@@ -1,26 +1,23 @@
-import { getServerSession } from 'next-auth';
 import { GET, PATCH } from '@/app/api/projects/[projectId]/route';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import * as projectRepository from '@/lib/repositories/project.repository';
 import {
   createMockGetRequest,
   createMockParams,
   createMockRequest,
-  createMockSession,
-  setupAuthMock,
   expectErrorResponse,
   expectSuccessResponse,
-  testUnauthenticatedAccess,
 } from '@test/utils/api-test-helpers';
 
-jest.mock('next-auth', () => ({
-  getServerSession: jest.fn(),
-}));
+jest.mock('@/lib/utils/api-auth');
 jest.mock('@/lib/auth', () => ({
   authOptions: {},
 }));
 jest.mock('@/lib/repositories/project.repository');
 
-const mockedGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockedRequireUserIdFromHeader = requireUserIdFromHeader as jest.MockedFunction<
+  typeof requireUserIdFromHeader
+>;
 const mockedGetProjectWithTopics = projectRepository.getProjectWithTopics as jest.MockedFunction<
   typeof projectRepository.getProjectWithTopics
 >;
@@ -36,19 +33,21 @@ describe('GET /api/projects/[projectId]', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    await testUnauthenticatedAccess(
-      GET,
-      mockedGetServerSession,
-      createMockParams({ projectId }),
-      createMockGetRequest(),
-    );
+  it('헤더가 없으면 throw한다', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
+    });
+
+    const req = createMockGetRequest();
+    const params = createMockParams({ projectId });
+
+    await expect(GET(req, params)).rejects.toThrow();
   });
 
   it('성공적으로 프로젝트를 조회한다', async () => {
     const mockProject = { id: projectId, title: 'Test Project', topics: [] };
 
-    setupAuthMock(mockedGetServerSession, createMockSession(userId));
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     mockedGetProjectWithTopics.mockResolvedValue(mockProject as any);
 
     const req = createMockGetRequest();
@@ -62,7 +61,7 @@ describe('GET /api/projects/[projectId]', () => {
   });
 
   it('존재하지 않는 프로젝트를 조회하면 404 에러를 반환한다', async () => {
-    setupAuthMock(mockedGetServerSession, createMockSession(userId));
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     mockedGetProjectWithTopics.mockResolvedValue(null);
 
     const req = createMockGetRequest();
@@ -81,19 +80,21 @@ describe('PATCH /api/projects/[projectId]', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    await testUnauthenticatedAccess(
-      PATCH,
-      mockedGetServerSession,
-      createMockParams({ projectId }),
-      createMockRequest({ title: 'Updated Title' }),
-    );
+  it('헤더가 없으면 throw한다', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
+    });
+
+    const req = createMockRequest({ title: 'Updated Title' });
+    const params = createMockParams({ projectId });
+
+    await expect(PATCH(req, params)).rejects.toThrow();
   });
 
   it('성공적으로 프로젝트를 수정한다', async () => {
     const mockProject = { id: projectId, title: 'Updated Title', description: 'Updated Desc' };
 
-    setupAuthMock(mockedGetServerSession, createMockSession(userId));
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     mockedUpdateProject.mockResolvedValue(mockProject as any);
 
     const req = createMockRequest({ title: 'Updated Title', description: 'Updated Desc' });

--- a/test/api/projects/route.test.ts
+++ b/test/api/projects/route.test.ts
@@ -1,13 +1,11 @@
 import { GET, POST, DELETE } from '@/app/api/projects/route';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import * as projectRepository from '@/lib/repositories/project.repository';
 import {
   createMockGetRequest,
   createMockRequest,
-  createMockSession,
   expectErrorResponse,
   expectSuccessResponse,
-  testUnauthenticatedAccess,
 } from '@test/utils/api-test-helpers';
 
 jest.mock('@/lib/utils/api-auth');
@@ -16,8 +14,8 @@ jest.mock('@/lib/auth', () => ({
 }));
 jest.mock('@/lib/repositories/project.repository');
 
-const mockedGetAuthenticatedUserId = getAuthenticatedUserId as jest.MockedFunction<
-  typeof getAuthenticatedUserId
+const mockedRequireUserIdFromHeader = requireUserIdFromHeader as jest.MockedFunction<
+  typeof requireUserIdFromHeader
 >;
 const mockedGetProjectsByUserMembership =
   projectRepository.getProjectsByUserMembership as jest.MockedFunction<
@@ -35,23 +33,13 @@ describe('GET /api/projects', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    const errorResponse = new Response(
-      JSON.stringify({
-        success: false,
-        data: null,
-        error: { code: 'UNAUTHORIZED', message: 'UNAUTHORIZED' },
-      }),
-      { status: 401, headers: { 'Content-Type': 'application/json' } },
-    );
-
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId: null,
-      error: errorResponse as any,
+  it('헤더가 없으면 throw한다 (proxy 매처 누락 시 발견)', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
     });
 
-    const response = await GET();
-    await expectErrorResponse(response, 401, 'UNAUTHORIZED');
+    const req = createMockGetRequest();
+    await expect(GET(req)).rejects.toThrow();
   });
 
   it('성공적으로 프로젝트 목록을 조회한다', async () => {
@@ -61,13 +49,11 @@ describe('GET /api/projects', () => {
       { id: 'project-2', title: 'Guest Project' },
     ];
 
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId,
-      error: null,
-    });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     mockedGetProjectsByUserMembership.mockResolvedValue(mockProjects as any);
 
-    const response = await GET();
+    const req = createMockGetRequest({ headers: { 'x-user-id': userId } });
+    const response = await GET(req);
     const data = await expectSuccessResponse(response, 200);
 
     expect(data).toHaveLength(2);
@@ -80,29 +66,18 @@ describe('POST /api/projects', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    const errorResponse = new Response(
-      JSON.stringify({
-        success: false,
-        data: null,
-        error: { code: 'UNAUTHORIZED', message: 'UNAUTHORIZED' },
-      }),
-      { status: 401, headers: { 'Content-Type': 'application/json' } },
-    );
-
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId: null,
-      error: errorResponse as any,
+  it('헤더가 없으면 throw한다', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
     });
 
     const req = createMockRequest({ title: 'New Project' });
-    const response = await POST(req);
-    await expectErrorResponse(response, 401, 'UNAUTHORIZED');
+    await expect(POST(req)).rejects.toThrow();
   });
 
   it('title이 없으면 400 에러를 반환한다', async () => {
     const userId = 'user-1';
-    mockedGetAuthenticatedUserId.mockResolvedValue({ userId, error: null });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
 
     const req = createMockRequest({});
     const response = await POST(req);
@@ -113,7 +88,7 @@ describe('POST /api/projects', () => {
     const userId = 'user-1';
     const mockProject = { id: 'project-1', title: 'New Project' };
 
-    mockedGetAuthenticatedUserId.mockResolvedValue({ userId, error: null });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     mockedCreateProject.mockResolvedValue(mockProject as any);
 
     const req = createMockRequest({ title: 'New Project', description: 'Description' });
@@ -130,29 +105,18 @@ describe('DELETE /api/projects', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    const errorResponse = new Response(
-      JSON.stringify({
-        success: false,
-        data: null,
-        error: { code: 'UNAUTHORIZED', message: 'UNAUTHORIZED' },
-      }),
-      { status: 401, headers: { 'Content-Type': 'application/json' } },
-    );
-
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId: null,
-      error: errorResponse as any,
+  it('헤더가 없으면 throw한다', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
     });
 
     const req = createMockRequest({ id: 'project-1' });
-    const response = await DELETE(req);
-    await expectErrorResponse(response, 401, 'UNAUTHORIZED');
+    await expect(DELETE(req)).rejects.toThrow();
   });
 
   it('id가 없으면 400 에러를 반환한다', async () => {
     const userId = 'user-1';
-    mockedGetAuthenticatedUserId.mockResolvedValue({ userId, error: null });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
 
     const req = createMockRequest({});
     const response = await DELETE(req);
@@ -163,7 +127,7 @@ describe('DELETE /api/projects', () => {
     const userId = 'user-1';
     const projectId = 'project-1';
 
-    mockedGetAuthenticatedUserId.mockResolvedValue({ userId, error: null });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     mockedDeleteProject.mockResolvedValue({ id: projectId } as any);
 
     const req = createMockRequest({ id: projectId });

--- a/test/api/topics/[topicId]/issues/route.test.ts
+++ b/test/api/topics/[topicId]/issues/route.test.ts
@@ -3,8 +3,7 @@ import { GET, POST } from '@/app/api/topics/[topicId]/issues/route';
 import { prisma } from '@/lib/prisma';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { createIssue } from '@/lib/repositories/issue.repository';
-import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
-import { createErrorResponse } from '@/lib/utils/api-helpers';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 import {
   createMockGetRequest,
   createMockParams,
@@ -38,8 +37,8 @@ const mockedCreateIssue = createIssue as jest.MockedFunction<typeof createIssue>
 const mockedAddIssueMember = issueMemberRepository.addIssueMember as jest.MockedFunction<
   typeof issueMemberRepository.addIssueMember
 >;
-const mockedGetAuthenticatedUserId = getAuthenticatedUserId as jest.MockedFunction<
-  typeof getAuthenticatedUserId
+const mockedRequireUserIdFromHeader = requireUserIdFromHeader as jest.MockedFunction<
+  typeof requireUserIdFromHeader
 >;
 const mockedPrismaTransaction = prisma.$transaction as jest.MockedFunction<
   typeof prisma.$transaction
@@ -89,26 +88,20 @@ describe('POST /api/topics/[topicId]/issues', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    const errorResponse = createErrorResponse('UNAUTHORIZED', 401);
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId: null,
-      error: errorResponse,
+  it('헤더가 없으면 throw한다', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
     });
     setupAuthMock(mockedGetServerSession, null);
 
     const req = createMockRequest({ title: 'New Issue' });
     const params = createMockParams({ topicId });
 
-    const response = await POST(req, params);
-    await expectErrorResponse(response, 401, 'UNAUTHORIZED');
+    await expect(POST(req, params)).rejects.toThrow();
   });
 
   it('title이 없으면 400 에러를 반환한다', async () => {
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId,
-      error: null,
-    });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     setupAuthMock(mockedGetServerSession, createMockSession(userId));
 
     const req = createMockRequest({});
@@ -130,10 +123,7 @@ describe('POST /api/topics/[topicId]/issues', () => {
       deletedAt: null,
     };
 
-    mockedGetAuthenticatedUserId.mockResolvedValue({
-      userId,
-      error: null,
-    });
+    mockedRequireUserIdFromHeader.mockReturnValue(userId);
     setupAuthMock(mockedGetServerSession, createMockSession(userId));
     mockedPrismaTransaction.mockImplementation(async (callback: any) => {
       mockedCreateIssue.mockResolvedValue(mockIssue as any);

--- a/test/api/topics/route.test.ts
+++ b/test/api/topics/route.test.ts
@@ -1,23 +1,21 @@
-import { getServerSession } from 'next-auth';
 import {
   createMockRequest,
-  createMockSession,
   expectErrorResponse,
   expectSuccessResponse,
-  setupAuthMock,
 } from '@test/utils/api-test-helpers';
 import { POST } from '@/app/api/topics/route';
 import * as topicRepository from '@/lib/repositories/topic.repository';
+import { requireUserIdFromHeader } from '@/lib/utils/api-auth';
 
-jest.mock('next-auth', () => ({
-  getServerSession: jest.fn(),
-}));
+jest.mock('@/lib/utils/api-auth');
 jest.mock('@/lib/auth', () => ({
   authOptions: {},
 }));
 jest.mock('@/lib/repositories/topic.repository');
 
-const mockedGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockedRequireUserIdFromHeader = requireUserIdFromHeader as jest.MockedFunction<
+  typeof requireUserIdFromHeader
+>;
 const mockedCreateTopic = topicRepository.createTopic as jest.MockedFunction<
   typeof topicRepository.createTopic
 >;
@@ -27,16 +25,17 @@ describe('POST /api/topics', () => {
     jest.clearAllMocks();
   });
 
-  it('인증되지 않은 사용자는 401 에러를 받는다', async () => {
-    setupAuthMock(mockedGetServerSession, null);
+  it('헤더가 없으면 throw한다', async () => {
+    mockedRequireUserIdFromHeader.mockImplementation(() => {
+      throw new Error('Missing x-user-id header');
+    });
 
     const req = createMockRequest({ title: 'New Topic', projectId: 'project-1' });
-    const response = await POST(req);
-    await expectErrorResponse(response, 401, 'UNAUTHORIZED');
+    await expect(POST(req)).rejects.toThrow();
   });
 
   it('title이 없으면 400 에러를 반환한다', async () => {
-    setupAuthMock(mockedGetServerSession, createMockSession('user-1'));
+    mockedRequireUserIdFromHeader.mockReturnValue('user-1');
 
     const req = createMockRequest({ projectId: 'project-1' });
     const response = await POST(req);
@@ -44,7 +43,7 @@ describe('POST /api/topics', () => {
   });
 
   it('projectId가 없으면 400 에러를 반환한다', async () => {
-    setupAuthMock(mockedGetServerSession, createMockSession('user-1'));
+    mockedRequireUserIdFromHeader.mockReturnValue('user-1');
 
     const req = createMockRequest({ title: 'New Topic' });
     const response = await POST(req);
@@ -54,7 +53,7 @@ describe('POST /api/topics', () => {
   it('성공적으로 토픽을 생성한다', async () => {
     const mockTopic = { id: 'topic-1', title: 'New Topic', projectId: 'project-1' };
 
-    setupAuthMock(mockedGetServerSession, createMockSession('user-1'));
+    mockedRequireUserIdFromHeader.mockReturnValue('user-1');
     mockedCreateTopic.mockResolvedValue(mockTopic as any);
 
     const req = createMockRequest({ title: 'New Topic', projectId: 'project-1' });
@@ -68,7 +67,7 @@ describe('POST /api/topics', () => {
   });
 
   it('에러 발생 시 500 에러를 반환한다', async () => {
-    setupAuthMock(mockedGetServerSession, createMockSession('user-1'));
+    mockedRequireUserIdFromHeader.mockReturnValue('user-1');
     mockedCreateTopic.mockRejectedValue(new Error('Database error'));
 
     const req = createMockRequest({ title: 'New Topic', projectId: 'project-1' });

--- a/test/auth/api-auth.test.ts
+++ b/test/auth/api-auth.test.ts
@@ -1,11 +1,6 @@
-// API 인증 유틸(getAuthenticatedUserId/getUserIdFromHeader) 단위 테스트
+// API 인증 유틸(getUserIdFromHeader/requireUserIdFromHeader) 단위 테스트
 // 테스트에서 사용할 요청 생성 헬퍼
 import { createMockRequest } from '@test/utils/api-test-helpers';
-
-// next-auth의 getServerSession을 모킹하여 세션 유무를 제어
-jest.mock('next-auth', () => ({
-  getServerSession: jest.fn(),
-}));
 
 // authOptions 의존성을 제거하기 위한 모킹
 jest.mock('@/lib/auth', () => ({
@@ -43,45 +38,23 @@ describe('api-auth', () => {
     expect(getUserIdFromHeader(req)).toBeNull();
   });
 
-  it('getAuthenticatedUserId는 세션이 없으면 UNAUTHORIZED를 반환한다', async () => {
-    // 테스트 대상 함수 로드
-    const { getAuthenticatedUserId } = await import('@/lib/utils/api-auth');
-    // 모킹된 getServerSession 획득
-    const { getServerSession } = await import('next-auth');
+  it('requireUserIdFromHeader는 헤더가 있으면 userId를 반환한다', async () => {
+    const { requireUserIdFromHeader } = await import('@/lib/utils/api-auth');
 
-    // 세션 없음으로 설정
-    (getServerSession as jest.Mock).mockResolvedValue(null);
+    const req = createMockRequest(undefined, {
+      headers: { 'x-user-id': 'user-1' },
+      method: 'GET',
+    });
 
-    // 실행
-    const result = await getAuthenticatedUserId();
-
-    // userId가 null인지 확인
-    expect(result.userId).toBeNull();
-    // 에러 객체 존재 확인
-    expect(result.error).toBeDefined();
-    // 401 상태 확인
-    expect(result.error!.status).toBe(401);
-
-    // 에러 코드 확인
-    const body = await result.error!.json();
-    expect(body.error.code).toBe('UNAUTHORIZED');
+    expect(requireUserIdFromHeader(req)).toBe('user-1');
   });
 
-  it('getAuthenticatedUserId는 세션이 있으면 userId를 반환한다', async () => {
-    // 테스트 대상 함수 로드
-    const { getAuthenticatedUserId } = await import('@/lib/utils/api-auth');
-    // 모킹된 getServerSession 획득
-    const { getServerSession } = await import('next-auth');
+  it('requireUserIdFromHeader는 헤더가 없으면 throw한다', async () => {
+    const { requireUserIdFromHeader } = await import('@/lib/utils/api-auth');
 
-    // 세션이 있는 경우로 설정
-    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 'user-1' } });
+    const req = createMockRequest(undefined, { method: 'GET' });
 
-    // 실행
-    const result = await getAuthenticatedUserId();
-
-    // userId가 반환되는지 확인
-    expect(result.userId).toBe('user-1');
-    // 에러가 없는지 확인
-    expect(result.error).toBeNull();
+    // proxy.ts 매처 누락 시 즉시 발견 가능하도록 throw
+    expect(() => requireUserIdFromHeader(req)).toThrow(/proxy\.ts matcher misconfigured/);
   });
 });

--- a/test/hooks/issue/use-ai-structure-mutation.test.ts
+++ b/test/hooks/issue/use-ai-structure-mutation.test.ts
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
 import { useAIStructuringMutation } from '@/hooks';
 import * as issueApi from '@/lib/api/issue';
+import { queryKeys } from '@/lib/query-keys';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
 // 1. 외부 의존성 모킹
@@ -107,10 +108,10 @@ describe('useAIStructuringMutation', () => {
 
       await waitFor(() => {
         expect(mockInvalidateQueries).toHaveBeenCalledWith({
-          queryKey: ['issues', issueId, 'categories'],
+          queryKey: queryKeys.issues.categories(issueId),
         });
         expect(mockInvalidateQueries).toHaveBeenCalledWith({
-          queryKey: ['issues', issueId, 'ideas'],
+          queryKey: queryKeys.issues.ideas(issueId),
         });
       });
     });

--- a/test/hooks/issue/use-category-mutation.test.ts
+++ b/test/hooks/issue/use-category-mutation.test.ts
@@ -7,6 +7,7 @@ import { useSseConnectionStore } from '@/app/(with-sidebar)/issues/store/use-sse
 import { CLIENT_ERROR_MESSAGES } from '@/constants/error-messages';
 import { useCategoryMutations } from '@/hooks';
 import * as categoryApi from '@/lib/api/category';
+import { queryKeys } from '@/lib/query-keys';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
 // 1. 외부 의존성 모킹
@@ -35,7 +36,7 @@ jest.mock('@/app/(with-sidebar)/issues/store/use-sse-connection-store', () => ({
 describe('useCategoryMutations', () => {
   const issueId = 'issue-123';
   const connectionId = 'conn-1';
-  const queryKey = ['issues', issueId, 'categories'];
+  const queryKey = queryKeys.issues.categories(issueId);
 
   // Mock 함수들
   const mockCreateCategory = categoryApi.createCategory as jest.Mock;

--- a/test/hooks/issue/use-idea-mutation.test.ts
+++ b/test/hooks/issue/use-idea-mutation.test.ts
@@ -6,6 +6,7 @@ import { toast } from 'react-hot-toast';
 import { useSseConnectionStore } from '@/app/(with-sidebar)/issues/store/use-sse-connection-store';
 import { useIdeaMutations } from '@/hooks';
 import * as ideaApi from '@/lib/api/idea';
+import { queryKeys } from '@/lib/query-keys';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
 // 1. 의존성 모킹
@@ -26,7 +27,7 @@ jest.mock('@tanstack/react-query', () => {
 describe('useIdeaMutations (Full Coverage)', () => {
   const issueId = 'issue-1';
   const connectionId = 'conn-1';
-  const queryKey = ['issues', issueId, 'ideas'];
+  const queryKey = queryKeys.issues.ideas(issueId);
 
   const mockCreateIdea = ideaApi.createIdea as jest.Mock;
   const mockUpdateIdea = ideaApi.updateIdea as jest.Mock;

--- a/test/hooks/issue/use-issue-member-mutation.test.ts
+++ b/test/hooks/issue/use-issue-member-mutation.test.ts
@@ -6,6 +6,7 @@ import { toast } from 'react-hot-toast';
 import { useSseConnectionStore } from '@/app/(with-sidebar)/issues/store/use-sse-connection-store';
 import { useIssueMemberMutations, useNicknameMutations, useUpdateNicknameMutation } from '@/hooks';
 import * as issueApi from '@/lib/api/issue';
+import { queryKeys } from '@/lib/query-keys';
 import * as storage from '@/lib/storage/issue-user-storage';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
@@ -91,7 +92,7 @@ describe('Issue Member & Nickname Mutations', () => {
 
       // 3. 쿼리 무효화 확인
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['issues', issueId, 'members'],
+        queryKey: queryKeys.issues.members(issueId),
       });
     });
 
@@ -175,7 +176,7 @@ describe('Issue Member & Nickname Mutations', () => {
 
       // 2. 쿼리 무효화 확인
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['issues', issueId, 'members'],
+        queryKey: queryKeys.issues.members(issueId),
       });
 
       // 3. 토스트 메시지 확인

--- a/test/hooks/issue/use-issue-mutation.test.ts
+++ b/test/hooks/issue/use-issue-mutation.test.ts
@@ -14,6 +14,7 @@ import {
   useUpdateIssueTitleMutation,
 } from '@/hooks';
 import * as issueApi from '@/lib/api/issue';
+import { queryKeys } from '@/lib/query-keys';
 import * as storage from '@/lib/storage/issue-user-storage';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
@@ -106,7 +107,7 @@ describe('Issue Mutations', () => {
 
   // 2. 이슈 상태 관리 (Status Update & Next Step)
   describe('useIssueStatusMutations', () => {
-    const queryKey = ['issues', issueId];
+    const queryKey = queryKeys.issues.detail(issueId);
 
     describe('handleNextStep (다음 단계 이동)', () => {
       test('BRAINSTORMING 상태에서 다음 단계인 CATEGORIZE로 업데이트해야 한다', async () => {
@@ -242,7 +243,7 @@ describe('Issue Mutations', () => {
       });
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['topics', topicId, 'issues'],
+        queryKey: queryKeys.topics.issues(topicId),
       });
       expect(mockToastSuccess).toHaveBeenCalledWith('이슈가 생성되었습니다!');
     });
@@ -271,7 +272,7 @@ describe('Issue Mutations', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(mockUpdateIssueTitle).toHaveBeenCalledWith(issueId, 'New Title', connectionId);
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['issues', issueId],
+        queryKey: queryKeys.issues.detail(issueId),
       });
       expect(mockToastSuccess).toHaveBeenCalledWith('이슈를 수정했습니다!');
     });
@@ -297,10 +298,10 @@ describe('Issue Mutations', () => {
         result.current.mutate({ connectionId });
       });
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(mockQueryClient.cancelQueries).toHaveBeenCalledWith({ queryKey: ['issues', issueId] });
-      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({ queryKey: ['issues', issueId] });
+      expect(mockQueryClient.cancelQueries).toHaveBeenCalledWith({ queryKey: queryKeys.issues.detail(issueId) });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({ queryKey: queryKeys.issues.detail(issueId) });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['topics', topicId],
+        queryKey: queryKeys.topics.detail(topicId),
       });
       expect(mockRouter.push).toHaveBeenCalledWith(`/topics/${topicId}`);
       expect(mockToastSuccess).toHaveBeenCalledWith('이슈를 삭제했습니다.');

--- a/test/hooks/issue/use-vote-mutation.test.ts
+++ b/test/hooks/issue/use-vote-mutation.test.ts
@@ -4,6 +4,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
 import { useVoteMutation } from '@/hooks';
+import { queryKeys } from '@/lib/query-keys';
 import * as voteApi from '@/lib/api/vote';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
@@ -28,7 +29,7 @@ jest.mock('@/app/(with-sidebar)/issues/store/use-sse-connection-store', () => ({
 describe('useVoteMutation', () => {
   const issueId = 'issue-1';
   const ideaId = 'idea-1';
-  const queryKey = ['issues', issueId, 'ideas'];
+  const queryKey = queryKeys.issues.ideas(issueId);
 
   const mockPostVote = voteApi.postVote as jest.Mock;
   const mockToastError = toast.error as jest.Mock;

--- a/test/hooks/project/use-project-mutation.test.ts
+++ b/test/hooks/project/use-project-mutation.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@/hooks';
 import * as leaveApi from '@/lib/api/leave';
 import * as projectApi from '@/lib/api/project';
+import { queryKeys } from '@/lib/query-keys';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
 // 1. 외부 모듈 모킹
@@ -62,7 +63,7 @@ describe('Project Mutations', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockCreateProject).toHaveBeenCalledWith('New Project', 'Desc');
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.projects.all() });
     });
 
     test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
@@ -114,7 +115,7 @@ describe('Project Mutations', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockDeleteProject).toHaveBeenCalledWith('proj-1');
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.projects.all() });
     });
 
     test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
@@ -151,8 +152,8 @@ describe('Project Mutations', () => {
       expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', 'Updated', 'New Desc');
 
       // 두 가지 쿼리 키가 무효화되었는지 확인
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['project', 'proj-1'] });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.projects.all() });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.projects.detail('proj-1') });
     });
 
     test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
@@ -204,7 +205,7 @@ describe('Project Mutations', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockLeaveProject).toHaveBeenCalledWith('proj-1', 'user-1');
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.projects.all() });
     });
 
     test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {

--- a/test/hooks/project/use-project-mutation.test.ts
+++ b/test/hooks/project/use-project-mutation.test.ts
@@ -65,10 +65,9 @@ describe('Project Mutations', () => {
       expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
     });
 
-    test('실패 시 에러 토스트를 띄워야 한다', async () => {
-      // Given
-      const errorMsg = '생성 실패';
-      mockCreateProject.mockRejectedValue(new Error(errorMsg));
+    test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
+      // Given: errorMessage가 설정된 경우 error.message와 무관하게 항상 errorMessage를 표시
+      mockCreateProject.mockRejectedValue(new Error('생성 실패'));
       const { result } = renderHook(() => useCreateProjectMutation());
 
       // When
@@ -78,10 +77,10 @@ describe('Project Mutations', () => {
 
       // Then
       await waitFor(() => expect(result.current.isError).toBe(true));
-      expect(mockToastError).toHaveBeenCalledWith(errorMsg);
+      expect(mockToastError).toHaveBeenCalledWith('프로젝트 생성에 실패했습니다.');
     });
 
-    test('에러 메시지가 없는 경우 기본 메시지("프로젝트 생성에 실패했습니다.")를 띄워야 한다', async () => {
+    test('에러 메시지가 없는 경우에도 고정 메시지("프로젝트 생성에 실패했습니다.")를 띄워야 한다', async () => {
       // Given: 메시지가 빈 에러 객체
       const error = new Error();
       error.message = '';
@@ -133,7 +132,6 @@ describe('Project Mutations', () => {
 
       // useDeleteProjectMutation은 토스트를 띄우지 않음
       expect(mockToastError).not.toHaveBeenCalled();
-      // console.error 호출 여부는 spyOn으로 인해 로그에는 안 찍히지만 내부는 실행됨
     });
   });
 
@@ -159,8 +157,8 @@ describe('Project Mutations', () => {
       expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['project', 'proj-1'] });
     });
 
-    test('실패 시 에러 토스트를 띄워야 한다', async () => {
-      // Given
+    test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
+      // Given: errorMessage가 설정된 경우 error.message와 무관하게 항상 errorMessage를 표시
       mockUpdateProject.mockRejectedValue(new Error('수정 실패'));
       const { result } = renderHook(() => useUpdateProjectMutation());
 
@@ -171,7 +169,7 @@ describe('Project Mutations', () => {
 
       // Then
       await waitFor(() => expect(result.current.isError).toBe(true));
-      expect(mockToastError).toHaveBeenCalledWith('수정 실패');
+      expect(mockToastError).toHaveBeenCalledWith('프로젝트 수정에 실패했습니다.');
     });
 
     test('에러 메시지가 없는 경우 기본 메시지("프로젝트 수정에 실패했습니다.")를 띄워야 한다', async () => {

--- a/test/hooks/project/use-project-mutation.test.ts
+++ b/test/hooks/project/use-project-mutation.test.ts
@@ -117,7 +117,7 @@ describe('Project Mutations', () => {
       expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
     });
 
-    test('실패 시 콘솔 에러가 찍혀야 한다 (토스트 호출 없음)', async () => {
+    test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
       // Given
       mockDeleteProject.mockRejectedValue(new Error('삭제 실패'));
       const { result } = renderHook(() => useDeleteProjectMutation());
@@ -129,9 +129,7 @@ describe('Project Mutations', () => {
 
       // Then
       await waitFor(() => expect(result.current.isError).toBe(true));
-
-      // useDeleteProjectMutation은 토스트를 띄우지 않음
-      expect(mockToastError).not.toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalledWith('프로젝트 삭제에 실패했습니다.');
     });
   });
 
@@ -209,7 +207,7 @@ describe('Project Mutations', () => {
       expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['projects'] });
     });
 
-    test('실패 시 콘솔 에러가 찍혀야 한다 (토스트 호출 없음)', async () => {
+    test('실패 시 고정된 에러 메시지를 토스트로 띄워야 한다', async () => {
       // Given
       mockLeaveProject.mockRejectedValue(new Error('나가기 실패'));
       const { result } = renderHook(() => useLeaveProjectMutation());
@@ -221,7 +219,7 @@ describe('Project Mutations', () => {
 
       // Then
       await waitFor(() => expect(result.current.isError).toBe(true));
-      expect(mockToastError).not.toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalledWith('프로젝트 나가기 실패했습니다.');
     });
   });
 });

--- a/test/hooks/topic/use-topic-mutation.test.ts
+++ b/test/hooks/topic/use-topic-mutation.test.ts
@@ -10,6 +10,7 @@ import {
   useUpdateTopicTitleMutation,
 } from '@/hooks';
 import * as topicApi from '@/lib/api/topic';
+import { queryKeys } from '@/lib/query-keys';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
 jest.mock('@/lib/api/topic');
@@ -113,7 +114,7 @@ describe('useTopicMutation', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['topics', topicId],
+        queryKey: queryKeys.topics.detail(topicId),
       });
       expect(toast.success).toHaveBeenCalledWith('토픽을 수정했습니다!');
     });
@@ -146,10 +147,10 @@ describe('useTopicMutation', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       // 삭제 프로세스 순서 검증
-      expect(mockQueryClient.cancelQueries).toHaveBeenCalledWith({ queryKey: ['topics', topicId] });
-      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({ queryKey: ['topics', topicId] });
+      expect(mockQueryClient.cancelQueries).toHaveBeenCalledWith({ queryKey: queryKeys.topics.detail(topicId) });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({ queryKey: queryKeys.topics.detail(topicId) });
       expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['project', projectId],
+        queryKey: queryKeys.projects.detail(projectId),
       });
       expect(mockRouter.push).toHaveBeenCalledWith(`/projects/${projectId}`);
       expect(toast.success).toHaveBeenCalledWith('토픽이 삭제되었습니다.');

--- a/test/hooks/topic/use-topic-mutations.test.ts
+++ b/test/hooks/topic/use-topic-mutations.test.ts
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
 import { useTopicMutations } from '@/hooks';
 import * as issueMapApi from '@/lib/api/issue-map';
+import { queryKeys } from '@/lib/query-keys';
 import { act, renderHook, waitFor } from '../../utils/test-utils';
 
 // 1. API 및 Toast 모킹
@@ -69,12 +70,12 @@ describe('useTopicMutations Hook', () => {
       // Then
       // 1. 기존 쿼리 취소 확인
       expect(mockCancelQueries).toHaveBeenCalledWith({
-        queryKey: ['topics', topicId, 'connections'],
+        queryKey: queryKeys.topics.connections(topicId),
       });
 
       // 2. 낙관적 업데이트 확인 (새로운 데이터가 즉시 추가되었는지)
       expect(mockSetQueryData).toHaveBeenCalledWith(
-        ['topics', topicId, 'connections'],
+        queryKeys.topics.connections(topicId),
         expect.arrayContaining([
           ...previousConnections,
           expect.objectContaining({
@@ -88,7 +89,7 @@ describe('useTopicMutations Hook', () => {
       expect(mockCreateConnection).toHaveBeenCalled();
       await waitFor(() => {
         expect(mockInvalidateQueries).toHaveBeenCalledWith({
-          queryKey: ['topics', topicId, 'connections'],
+          queryKey: queryKeys.topics.connections(topicId),
         });
       });
     });
@@ -117,7 +118,7 @@ describe('useTopicMutations Hook', () => {
       // 롤백 확인: setQueryData가 이전 데이터(previousConnections)로 다시 호출되었는지
       // (첫 번째 호출은 낙관적 업데이트, 두 번째 호출이 롤백이어야 함)
       expect(mockSetQueryData).toHaveBeenLastCalledWith(
-        ['topics', topicId, 'connections'],
+        queryKeys.topics.connections(topicId),
         previousConnections, // 롤백된 데이터
       );
     });
@@ -145,7 +146,7 @@ describe('useTopicMutations Hook', () => {
 
       // 낙관적 업데이트: conn-2가 제거된 배열로 setQueryData 호출
       expect(mockSetQueryData).toHaveBeenCalledWith(
-        ['topics', topicId, 'connections'],
+        queryKeys.topics.connections(topicId),
         [{ id: 'conn-1' }],
       );
 
@@ -170,7 +171,7 @@ describe('useTopicMutations Hook', () => {
 
       // 롤백 확인
       expect(mockSetQueryData).toHaveBeenLastCalledWith(
-        ['topics', topicId, 'connections'],
+        queryKeys.topics.connections(topicId),
         previousConnections,
       );
     });
@@ -194,11 +195,11 @@ describe('useTopicMutations Hook', () => {
       });
 
       // Then
-      expect(mockCancelQueries).toHaveBeenCalledWith({ queryKey: ['topics', topicId, 'nodes'] });
+      expect(mockCancelQueries).toHaveBeenCalledWith({ queryKey: queryKeys.topics.nodes(topicId) });
 
       // 낙관적 업데이트 확인: node-1의 좌표가 바뀐 상태로 저장되었는지
       expect(mockSetQueryData).toHaveBeenCalledWith(
-        ['topics', topicId, 'nodes'],
+        queryKeys.topics.nodes(topicId),
         [
           expect.objectContaining({ id: 'node-1', positionX: 100, positionY: 100 }), // 변경됨
           expect.objectContaining({ id: 'node-2', positionX: 10, positionY: 10 }), // 그대로
@@ -224,7 +225,7 @@ describe('useTopicMutations Hook', () => {
 
       // 롤백 확인: 원래 좌표(0,0)인 previousNodes로 다시 덮어씌웠는지 확인
       expect(mockSetQueryData).toHaveBeenLastCalledWith(
-        ['topics', topicId, 'nodes'],
+        queryKeys.topics.nodes(topicId),
         previousNodes,
       );
     });

--- a/test/hooks/user/use-user-mutation.test.ts
+++ b/test/hooks/user/use-user-mutation.test.ts
@@ -75,9 +75,8 @@ describe('useUserMutation', () => {
     });
 
     test('회원탈퇴 실패 시 에러 토스트를 띄워야 한다', async () => {
-      // Given: API 실패 가정
-      const errorMessage = '탈퇴 처리 중 오류 발생';
-      mockWithdraw.mockRejectedValue(new Error(errorMessage));
+      // Given: errorMessage가 설정된 경우 error.message와 무관하게 항상 errorMessage를 표시
+      mockWithdraw.mockRejectedValue(new Error('탈퇴 처리 중 오류 발생'));
 
       const { result } = renderHook(() => useUserMutation());
 
@@ -89,8 +88,8 @@ describe('useUserMutation', () => {
       // Then: 에러 상태 대기
       await waitFor(() => expect(result.current.withdrawMutation.isError).toBe(true));
 
-      // 1. 에러 토스트 확인
-      expect(mockToastError).toHaveBeenCalledWith(errorMessage);
+      // 1. 에러 토스트 확인 (errorMessage가 항상 우선)
+      expect(mockToastError).toHaveBeenCalledWith('회원탈퇴 중 오류가 발생했습니다.');
 
       // 2. 실패 시에는 로그아웃이나 캐시 초기화가 실행되면 안 됨
       expect(mockSignOut).not.toHaveBeenCalled();
@@ -172,8 +171,8 @@ describe('useUserMutation', () => {
 
       await waitFor(() => expect(result.current.updateDisplayNameMutation.isError).toBe(true));
 
-      // 기본 메시지 확인
-      expect(mockToastError).toHaveBeenCalledWith('이름 변경 중 오류가 발생했습니다.');
+      // errorMessage가 없으므로 최종 fallback 메시지 표시
+      expect(mockToastError).toHaveBeenCalledWith('오류가 발생했습니다.');
     });
   });
 });

--- a/test/utils/test-utils.tsx
+++ b/test/utils/test-utils.tsx
@@ -1,15 +1,30 @@
 import React, { ReactElement } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RenderHookOptions, RenderOptions, render, renderHook } from '@testing-library/react';
+import toast from 'react-hot-toast';
 import { AuthProvider } from '@/providers/auth-provider';
 
 // 1. 전역 래퍼 (RootLayout 구조 반영)
 const createWrapper = () => {
-  // 테스트용 쿼리 클라이언트
+  // 테스트용 쿼리 클라이언트 (query-provider.tsx의 makeQueryClient와 동일한 설정)
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
+      mutations: { retry: false },
     },
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        const label = mutation.meta?.errorLabel ?? '[Mutation Error]';
+        console.error(`${label}:`, error);
+
+        if (mutation.meta?.disableGlobalToast) return;
+
+        const message = mutation.meta?.errorMessage
+          || (error instanceof Error ? error.message : null)
+          || '오류가 발생했습니다.';
+        toast.error(message);
+      },
+    }),
   });
 
   return ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
## 관련 이슈

#17

---

## 완료 작업

<!-- 이 PR에서 완료된 주요 내용을 간단히 설명해주세요 -->
- 유저 인증 중복 로직 > 미들웨어 헬퍼로 분리
- 500 에러 헬퍼 통일
- 리액트 쿼리 뮤테이션 onError 중앙 처리
- React Query queryKey 팩토리 패턴 도입

---

## 기타

<!-- 코드 리뷰 시 참고할 사항을 작성해주세요 -->
<!-- 특히 주의깊게 봐야 하는 파일이나 코드가 있다면 명시해주세요 -->
<!-- 구현 중 고민했던 부분이나 리뷰어에게 질문하고 싶은 내용을 적어주세요 -->

## ai 정리
<h2 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">리팩토링: API 인증 미들웨어 분리 / 에러 응답 통일 / React Query 중앙화</h2><h3 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">작업 배경</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">코드베이스 전반에 걸쳐 동일한 패턴이 여러 파일에 반복 작성되어 있었습니다. 기능상 문제는 없지만 유지보수 비용이 높고, 수정 시 누락되는 파일이 생기기 쉬운 구조였습니다. 이번 PR은 세 가지 중복 패턴을 각각 단일 지점으로 통합하는 작업입니다.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1. API 라우트 유저 인증 중복 코드 → 미들웨어 헬퍼로 분리</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>문제</strong>
<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">x-user-id</code> 헤더에서 userId를 꺼내고 없으면 500을 반환하는 코드가 API 라우트마다 반복되었습니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>해결</strong>
<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/lib/utils/api-auth.ts</code>에 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">requireUserIdFromHeader()</code> 헬퍼를 추가했습니다. userId가 없으면 즉시 서버 에러를 던지고, 있으면 userId 문자열을 반환합니다. 각 라우트는 한 줄 호출로 대체됩니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>효과</strong></p><ul style="padding-inline-start: 2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>인증 처리 로직이 단일 함수에 집중되어 변경 시 한 곳만 수정하면 됩니다.</li><li>6개 라우트 파일에서 보일러플레이트 107줄 → 32줄로 감소했습니다.</li></ul><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">2. 500 에러 응답 헬퍼 통일 + 에러 코드 정리</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>문제</strong>
예상치 못한 에러를 잡는 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">catch</code> 블록에서 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">createErrorResponse(500, 'INTERNAL_ERROR', ...)</code> 형태의 코드가 20개 이상의 라우트에 흩어져 있었습니다. 에러 코드명도 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INTERNAL_ERROR</code> / <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INTERNAL_SERVER_ERROR</code>가 혼용되었습니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>해결</strong></p><ul style="padding-inline-start: 2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/lib/utils/api-helpers.ts</code>에<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">handleApiError()</code><span> </span>헬퍼를 추가했습니다. 내부적으로<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">createErrorResponse</code>를 호출하며, 500 응답의 형태를 한 곳에서 관리합니다.</li><li>에러 코드를<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INTERNAL_SERVER_ERROR</code>로 통일했습니다.</li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/constants/error-messages.ts</code>에 누락된 에러 메시지를 추가했습니다.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>효과</strong></p><ul style="padding-inline-start: 2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>모든 catch 블록이<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">return handleApiError(error)</code><span> </span>한 줄로 통일되었습니다.</li><li>500 응답 포맷 변경 시 한 파일만 수정하면 됩니다.</li></ul><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">3. React Query mutation onError 중앙 처리 (MutationCache)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>문제</strong>
각 mutation hook의 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onError</code> 콜백에 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">console.error</code>와 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">toast.error</code>를 직접 작성하는 패턴이 반복되었습니다. 에러 메시지도 각 hook마다 따로 하드코딩되어 있었습니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>해결</strong>
<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/providers/query-provider.tsx</code>에 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">MutationCache</code>의 전역 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onError</code> 핸들러를 추가했습니다.</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(40, 42, 54); border-color: rgb(69, 69, 69); border-style: solid; border-width: 0.694444px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-ts" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mutationCache: new MutationCache({
  onError: (error, _variables, _context, mutation) =&gt; {
    const label = mutation.meta?.errorLabel ?? '[Mutation Error]';
    console.error(`${label}:`, error); // 항상 로깅

    if (mutation.meta?.disableGlobalToast) return; // 커스텀 토스트가 필요한 경우만 스킵

    const message =
      mutation.meta?.errorMessage ||
      (error instanceof Error ? error.message : null) ||
      '오류가 발생했습니다.';
    toast.error(message);
  },
}),
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">각 mutation hook은 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">meta</code> 필드만 선언하면 됩니다.</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(40, 42, 54); border-color: rgb(69, 69, 69); border-style: solid; border-width: 0.694444px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-ts" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">// before
onError: (error) =&gt; {
  console.error('프로젝트 삭제 실패:', error);
  toast.error('프로젝트 삭제에 실패했습니다.');
}

// after
meta: { errorLabel: '프로젝트 삭제 실패', errorMessage: '프로젝트 삭제에 실패했습니다.' }
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">errorMessage</code>를 설정하면 항상 해당 고정 메시지를 표시합니다. 설정하지 않으면 서버에서 내려온 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">error.message</code>가 그대로 노출됩니다 (유효성 검사 에러 등 서버 메시지를 그대로 보여줘야 하는 경우).</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">disableGlobalToast: true</code>는 조건에 따라 다른 토스트를 띄워야 하는 경우(예: <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">useUpdateNicknameMutation</code>)에만 사용합니다. 로깅(<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">console.error</code>)은 이 경우에도 항상 실행됩니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">타입 안전성을 위해 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/types/react-query.d.ts</code>에 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mutationMeta</code> 인터페이스를 선언했습니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>효과</strong></p><ul style="padding-inline-start: 2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>개별 mutation hook에서<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onError</code><span> </span>콜백 블록이 제거되어 코드가 간결해졌습니다.</li><li>에러 로깅/토스트 동작을 한 곳에서 변경할 수 있습니다.</li><li>컴포넌트의 호출부(<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mutate()</code><span> </span>옵션)에 있던<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onError: () =&gt; toast.error(...)</code><span> </span>도 제거되었습니다.</li></ul><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">4. React Query queryKey 팩토리 패턴 도입</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>문제</strong>
<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">['issues', issueId, 'ideas']</code> 같은 쿼리 키 배열이 hook, 컴포넌트, SSE 이벤트 핸들러 등 30개 이상의 파일에 인라인으로 흩어져 있었습니다. 오타가 발생해도 타입 에러가 나지 않고, 키 구조 변경 시 전체 파일을 찾아 수정해야 했습니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>해결</strong>
<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/lib/query-keys.ts</code>에 도메인별 팩토리 함수를 정의했습니다.</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(40, 42, 54); border-color: rgb(69, 69, 69); border-style: solid; border-width: 0.694444px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-ts" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">export const queryKeys = {
  projects: {
    all: () =&gt; ['projects'] as const,
    detail: (projectId: string) =&gt; ['project', projectId] as const,
  },
  issues: {
    detail: (issueId: string) =&gt; ['issues', issueId] as const,
    ideas: (issueId: string) =&gt; ['issues', issueId, 'ideas'] as const,
    categories: (issueId: string) =&gt; ['issues', issueId, 'categories'] as const,
    members: (issueId: string) =&gt; ['issues', issueId, 'members'] as const,
    selectedIdea: (issueId: string) =&gt; ['issues', issueId, 'selected-idea'] as const,
    ...
  },
  topics: { ... },
  comments: {
    list: (issueId: string, ideaId: string) =&gt; ['comments', issueId, ideaId] as const,
  },
};
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">기존에 각 query hook 파일에 흩어져 있던 <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">selectedIdeaQueryKey</code> 같은 개별 export도 이 팩토리로 통합되었습니다.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>효과</strong></p><ul style="padding-inline-start: 2em; color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>키 구조 변경 시<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">query-keys.ts</code><span> </span>한 파일만 수정하면 됩니다.</li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">as const</code>로 타입이 좁혀져 오타가 컴파일 타임에 잡힙니다.</li><li>코드베이스 내 인라인 queryKey 배열이 0개가 되었습니다.</li></ul><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(248, 248, 242); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(33, 34, 44); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">변경 파일 요약</h3>
영역 | 주요 변경
-- | --
src/lib/utils/api-auth.ts | requireUserIdFromHeader 헬퍼 추가
src/lib/utils/api-helpers.ts | handleApiError 헬퍼 추가
src/constants/error-messages.ts | 누락 에러 메시지 추가, 에러 코드 통일
src/providers/query-provider.tsx | MutationCache 전역 에러 핸들러 추가
src/types/react-query.d.ts | mutationMeta 타입 선언 추가
src/lib/query-keys.ts | queryKey 팩토리 신규 생성
src/app/api/** (20+ 파일) | 인증 헬퍼, 에러 헬퍼 적용
src/hooks/** (20+ 파일) | onError 제거 → meta 선언으로 대체, queryKeys 팩토리 적용
src/issues/hooks/use-issue-events.ts | 인라인 queryKey 배열 → 팩토리
test/** (20+ 파일) | 변경된 동작에 맞게 테스트 코드 수정


